### PR TITLE
Add Unique UUID for each .tmTheme file

### DIFF
--- a/Darkside.tmTheme
+++ b/Darkside.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>26FC6CC3-0A07-462F-8FBE-9773CBF0D28D</string>
 </dict>
 </plist>

--- a/Earthsong.tmTheme
+++ b/Earthsong.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>6AC5629A-D5D9-4337-9674-6355EB039ADB</string>
 </dict>
 </plist>

--- a/EarthsongLight.tmTheme
+++ b/EarthsongLight.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>1288CE68-F6B6-4E5F-B419-41BC59FBE56F</string>
 </dict>
 </plist>

--- a/FreshCut.tmTheme
+++ b/FreshCut.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>09D1BE89-328E-4197-8CAE-1772B6C61DF9</string>
 </dict>
 </plist>

--- a/Frontier.tmTheme
+++ b/Frontier.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>16777B7F-33F3-4EFD-BC60-25C952FF724E</string>
 </dict>
 </plist>

--- a/Goldfish.tmTheme
+++ b/Goldfish.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>E6EA2CC0-9B10-45D1-8896-214832727C82</string>
 </dict>
 </plist>

--- a/Grunge.tmTheme
+++ b/Grunge.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>4963E6D1-D531-43B5-A2E1-CFA8C2625A5E</string>
 </dict>
 </plist>

--- a/Iceberg.tmTheme
+++ b/Iceberg.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>FF7EBFD5-C01C-4748-8193-D0FF60FB54B0</string>
 </dict>
 </plist>

--- a/Laravel.tmTheme
+++ b/Laravel.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>B9A9A975-9D9D-489A-9053-DE4D932E91F5</string>
 </dict>
 </plist>

--- a/LaravelDarker.tmTheme
+++ b/LaravelDarker.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>FFC5C692-05C6-4E8A-820C-AE457C1FAAE2</string>
 </dict>
 </plist>

--- a/Lavender.tmTheme
+++ b/Lavender.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>F0BB0D67-87D9-4B6C-98E2-7DB00D3981EF</string>
 </dict>
 </plist>

--- a/Mellow.tmTheme
+++ b/Mellow.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>314102C1-8E0E-49E3-AB07-8FEFAD52CFE0</string>
 </dict>
 </plist>

--- a/Patriot.tmTheme
+++ b/Patriot.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>883FBB32-8100-41C6-8BFD-5C4F674E5B3F</string>
 </dict>
 </plist>

--- a/Peacock.tmTheme
+++ b/Peacock.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>2FE74F49-E4DC-415F-A355-DC9EBAEF3234</string>
 </dict>
 </plist>

--- a/Potpourri.tmTheme
+++ b/Potpourri.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>55B0DD79-A2F9-4D7F-B1D6-E5BFA1788D46</string>
 </dict>
 </plist>

--- a/Revelation.tmTheme
+++ b/Revelation.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>F11D1353-A93B-4217-B675-942037877D1B</string>
 </dict>
 </plist>

--- a/Slime.tmTheme
+++ b/Slime.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>F3A33D4E-EB70-4940-BF29-3AE7B88A6514</string>
 </dict>
 </plist>

--- a/Snappy.tmTheme
+++ b/Snappy.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>03ABBF89-0688-42AC-951D-437AD6E93152</string>
 </dict>
 </plist>

--- a/SnappyLight.tmTheme
+++ b/SnappyLight.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>12632AED-5F4D-40DE-ABBC-F49C7B98C153</string>
 </dict>
 </plist>

--- a/Sourlick.tmTheme
+++ b/Sourlick.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>C058D360-784E-4CC6-B247-203A94D106D6</string>
 </dict>
 </plist>

--- a/Spearmint.tmTheme
+++ b/Spearmint.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>34CE9CB0-B003-490F-8422-33E8C28B06E7</string>
 </dict>
 </plist>

--- a/Stark.tmTheme
+++ b/Stark.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>128129AD-81C0-454B-89E3-47256C94D40C</string>
 </dict>
 </plist>

--- a/Userscape.tmTheme
+++ b/Userscape.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>EB59E9AE-9B29-496B-9278-C656AF7B9A0B</string>
 </dict>
 </plist>

--- a/Yule.tmTheme
+++ b/Yule.tmTheme
@@ -393,6 +393,6 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 
 	</array>
 	<key>uuid</key>
-	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>
+	<string>4C23EE5F-DCF6-4D78-BA50-CA6E3453ACA2</string>
 </dict>
 </plist>


### PR DESCRIPTION
I order to make a TextMate 2 compliant bundle, a number of requirements must be satisfied:
- `.tmTheme` files must have an unique UUID
- `.tmTheme` files must reside in a `Themes` directory.
- A `info.plist` file must reside in the root of the bundle.

This pull request fixes the first requirement.

I'm not quite sure what folder structure the Package Manager of Sublime Text 2 rely on, so therefor I decided to wait to push any further changes.
