### PR TITLE
Remove sexism from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Based on Pink Floyd's 'dark side of the moon', a request by Jamie Rumbelow.
 
 ### Lavender
 
-Here's one for the ladies, Lavender.
+With all of the color but none of the scent: Lavender.
 
 ![Lavender](https://raw.github.com/daylerees/colour-schemes/master/screenshots/lavender.png)
 


### PR DESCRIPTION
I do not believe that any harm was intended behind this comment, but
a seemingly harmless joke such as women preferring pinks and purples
because society has deemed them to be "girly" colors is more likely to
be a bad thing. It is an example of "special" treatment in a field where
women do not want to be treated differently for being women.
Additionally, it perpetuates the idea that pinks and purples can not be
for men. But come on, guys: who doesn't like purple? Seriously.

Signed-off-by: David Celis me@davidcel.is
