### PR TITLE
Darken JSON strings in SnappyLight

### DIFF
--- a/SnappyLight.tmTheme
+++ b/SnappyLight.tmTheme
@@ -323,7 +323,7 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#CFCFC2</string>
+				<string>#7C7C74</string>
 			</dict>
 		</dict>
 


### PR DESCRIPTION
JSON was so light as to be unusable by me so I darkened it by a couple shades.

Before: ![](http://f.cl.ly/items/2T342N1H3J3d421l0h2U/Q1fqJ_.png)

After: ![](http://f.cl.ly/items/3e0J1Z0M1p202K0H2A1U/G7z2v7.png)
