### PR TITLE
Switch Darkside selection value for better visibilty on dark background

### DIFF
--- a/Darkside.tmTheme
+++ b/Darkside.tmTheme
@@ -31,7 +31,7 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 				<key>lineHighlight</key>
 				<string>#303333</string>
 				<key>selection</key>
-				<string>#161A1F</string>
+				<string>#303333</string>
 				<key>findHighlight</key>
 				<string>#FFE792</string>
 				<key>findHighlightForeground</key>


### PR DESCRIPTION
Switch selection to #303333 for dark/black backgrounds.
