### PR TITLE
Updated Stark theme to support LaTeX source

### DIFF
--- a/Stark.tmTheme
+++ b/Stark.tmTheme
@@ -472,6 +472,15 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 				<string>#617FA0</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>scope</key>
+			<string>text.tex.latex string.other.math.tex punctuation.definition.string.end.tex</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#617FA0</string>
+			</dict>
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>128129AD-81C0-454B-89E3-47256C94D40C</string>


### PR DESCRIPTION
LaTeX code was [not very good]() with the current Stark theme, so I updated it with very specific scopes for LaTeX.  Some of the colors could probably be adjusted some, but I found this much more appealing than all gold and white.

[old](http://puu.sh/21tdH/e38b4bec70)

[new](http://puu.sh/21wEl/c9f645d28f)
