### PR TITLE
fixed github comment color. Was red, which is not the proper color.

### DIFF
--- a/Github.tmTheme
+++ b/Github.tmTheme
@@ -63,7 +63,7 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#d14</string>
+				<string>#b8b6b1</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
The previous pull-request #63 changed the comment color to the same color as strings. This is incorrect. Reverting back to the previous color.
