### PR TITLE
Fix for proper Vim/Vundle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Download or clone the colour schemes repository with git into your `.vim/colors`
 Add the following to your `.vimrc`:
 
 ```viml
-Bundle "daylerees/colour-schemes", { "rtp": "vim-themes/" }
+Bundle "daylerees/colour-schemes", { "rtp": "vim/" }
 ```
 
 ---

--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
     <!-- Refresh destination directories. -->
     <target name="clean">
         <delete dir="${basedir}/sublime"/>
-        <delete dir="${basedir}/vim"/>
+        <delete dir="${basedir}/vim/colors"/>
         <delete dir="${basedir}/preview"/>
         <delete dir="${basedir}/prettyprint"/>
         <delete dir="${basedir}/coda"/>


### PR DESCRIPTION
Vim and Vundle expect color schemes to exist inside a `colors` directory rather than a root `vim` directory, so I've moved all .vim files and updated the README accordingly.

I also updated the build.xml, but I didn't see any instructions for how to run a build to test my change. Please let me know if I've somehow broken the build process and I'll make any necessary changes.

Hope this helps!
