### PR TITLE
Fix theme.name bug for Vim

### DIFF
--- a/build/patterns/vim/vim.pattern
+++ b/build/patterns/vim/vim.pattern
@@ -101,5 +101,5 @@ hi link htmlH6 htmlH5
 " And finally.
 
 let g:colors_name = "{{ theme.name }}"
-let colors_name   = "theme.name"
+let colors_name   = "{{ theme.name }}"
 


### PR DESCRIPTION
Just an overlooked template language bug, looks like. Causes an error when running Vim with one of these themes installed.
