### PR TITLE
Correct TextMate instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Clone the repository and copy the theme files into `~/Library/Application\ Suppo
 
 ```sh
 $ git clone https://github.com/daylerees/colour-schemes.git daylerees-themes
-$ cd daylerees-themes/legacy
+$ cd daylerees-themes/sublime
 $ mkdir ~/Library/Application\ Support/TextMate/Themes/
 $ cp *.tmTheme ~/Library/Application\ Support/TextMate/Themes/
 ```
@@ -72,7 +72,7 @@ Clone the repository and copy the theme files into `~/Library/Application\ Suppo
 
 ```sh
 $ git clone https://github.com/daylerees/colour-schemes.git daylerees-themes
-$ cd daylerees-themes/legacy
+$ cd daylerees-themes/sublime
 $ cp *.tmTheme ~/Library/Application\ Support/TextMate/Managed/Bundles/Themes.tmbundle/Themes/
 ```
 


### PR DESCRIPTION
`.tmTheme` files are now in `/legacy`, so this slight README tweak fixes the installation instructions
