### PR TITLE
Disabling default Sublime Text 3 icons

### DIFF
--- a/build/resources/patterns/sublimeui/sublimeui.pattern
+++ b/build/resources/patterns/sublimeui/sublimeui.pattern
@@ -1063,8 +1063,23 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
 
+        {
+            "class": "icon_file_type",
+            "content_margin": [0,0]
+        },
+        {
+            "class": "icon_folder",
+            "content_margin": [0,0]
+        },
+        {
+            "class": "icon_folder_loading",
+            "content_margin": [0,0]
+        }
 ]
 
 {% else %}
@@ -2129,7 +2144,23 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]
 {% endif %}

--- a/sublimeui/arstotzka.sublime-theme
+++ b/sublimeui/arstotzka.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/azure.sublime-theme
+++ b/sublimeui/azure.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/bold.sublime-theme
+++ b/sublimeui/bold.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/boxuk.sublime-theme
+++ b/sublimeui/boxuk.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/carbonight.sublime-theme
+++ b/sublimeui/carbonight.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/chocolate.sublime-theme
+++ b/sublimeui/chocolate.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/carbonight-contrast.sublime-theme
+++ b/sublimeui/contrast/carbonight-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/darkside-contrast.sublime-theme
+++ b/sublimeui/contrast/darkside-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/earthsong-contrast.sublime-theme
+++ b/sublimeui/contrast/earthsong-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/freshcut-contrast.sublime-theme
+++ b/sublimeui/contrast/freshcut-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/frontier-contrast.sublime-theme
+++ b/sublimeui/contrast/frontier-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/gloom-contrast.sublime-theme
+++ b/sublimeui/contrast/gloom-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/glowfish-contrast.sublime-theme
+++ b/sublimeui/contrast/glowfish-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/goldfish-contrast.sublime-theme
+++ b/sublimeui/contrast/goldfish-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/grunge-contrast.sublime-theme
+++ b/sublimeui/contrast/grunge-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/halflife-contrast.sublime-theme
+++ b/sublimeui/contrast/halflife-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/hyrule-contrast.sublime-theme
+++ b/sublimeui/contrast/hyrule-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/iceberg-contrast.sublime-theme
+++ b/sublimeui/contrast/iceberg-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/juicy-contrast.sublime-theme
+++ b/sublimeui/contrast/juicy-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/keen-contrast.sublime-theme
+++ b/sublimeui/contrast/keen-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/laravel-contrast.sublime-theme
+++ b/sublimeui/contrast/laravel-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/lavender-contrast.sublime-theme
+++ b/sublimeui/contrast/lavender-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/mellow-contrast.sublime-theme
+++ b/sublimeui/contrast/mellow-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/mud-contrast.sublime-theme
+++ b/sublimeui/contrast/mud-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/patriot-contrast.sublime-theme
+++ b/sublimeui/contrast/patriot-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/peacock-contrast.sublime-theme
+++ b/sublimeui/contrast/peacock-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/potpourri-contrast.sublime-theme
+++ b/sublimeui/contrast/potpourri-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/revelation-contrast.sublime-theme
+++ b/sublimeui/contrast/revelation-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/slime-contrast.sublime-theme
+++ b/sublimeui/contrast/slime-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/snappy-contrast.sublime-theme
+++ b/sublimeui/contrast/snappy-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/solarflare-contrast.sublime-theme
+++ b/sublimeui/contrast/solarflare-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/sourlick-contrast.sublime-theme
+++ b/sublimeui/contrast/sourlick-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/stark-contrast.sublime-theme
+++ b/sublimeui/contrast/stark-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/tron-contrast.sublime-theme
+++ b/sublimeui/contrast/tron-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/turnip-contrast.sublime-theme
+++ b/sublimeui/contrast/turnip-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/contrast/zacks-contrast.sublime-theme
+++ b/sublimeui/contrast/zacks-contrast.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/crisp.sublime-theme
+++ b/sublimeui/crisp.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/darkside.sublime-theme
+++ b/sublimeui/darkside.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/earthsong.sublime-theme
+++ b/sublimeui/earthsong.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/freshcut.sublime-theme
+++ b/sublimeui/freshcut.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/frontier.sublime-theme
+++ b/sublimeui/frontier.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/github.sublime-theme
+++ b/sublimeui/github.sublime-theme
@@ -1062,7 +1062,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
 
+        {
+            "class": "icon_file_type",
+            "content_margin": [0,0]
+        },
+        {
+            "class": "icon_folder",
+            "content_margin": [0,0]
+        },
+        {
+            "class": "icon_folder_loading",
+            "content_margin": [0,0]
+        }
 ]
 

--- a/sublimeui/gloom.sublime-theme
+++ b/sublimeui/gloom.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/glowfish.sublime-theme
+++ b/sublimeui/glowfish.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/goldfish.sublime-theme
+++ b/sublimeui/goldfish.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/grunge.sublime-theme
+++ b/sublimeui/grunge.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/halflife.sublime-theme
+++ b/sublimeui/halflife.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/heroku.sublime-theme
+++ b/sublimeui/heroku.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/hyrule.sublime-theme
+++ b/sublimeui/hyrule.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/iceberg.sublime-theme
+++ b/sublimeui/iceberg.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/juicy.sublime-theme
+++ b/sublimeui/juicy.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/keen.sublime-theme
+++ b/sublimeui/keen.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/kiwi.sublime-theme
+++ b/sublimeui/kiwi.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/laravel.sublime-theme
+++ b/sublimeui/laravel.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/lavender.sublime-theme
+++ b/sublimeui/lavender.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/legacy.sublime-theme
+++ b/sublimeui/legacy.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/light/earthsong-light.sublime-theme
+++ b/sublimeui/light/earthsong-light.sublime-theme
@@ -1062,7 +1062,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
 
+        {
+            "class": "icon_file_type",
+            "content_margin": [0,0]
+        },
+        {
+            "class": "icon_folder",
+            "content_margin": [0,0]
+        },
+        {
+            "class": "icon_folder_loading",
+            "content_margin": [0,0]
+        }
 ]
 

--- a/sublimeui/light/snappy-light.sublime-theme
+++ b/sublimeui/light/snappy-light.sublime-theme
@@ -1062,7 +1062,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
 
+        {
+            "class": "icon_file_type",
+            "content_margin": [0,0]
+        },
+        {
+            "class": "icon_folder",
+            "content_margin": [0,0]
+        },
+        {
+            "class": "icon_folder_loading",
+            "content_margin": [0,0]
+        }
 ]
 

--- a/sublimeui/light/userscape.sublime-theme
+++ b/sublimeui/light/userscape.sublime-theme
@@ -1062,7 +1062,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
 
+        {
+            "class": "icon_file_type",
+            "content_margin": [0,0]
+        },
+        {
+            "class": "icon_folder",
+            "content_margin": [0,0]
+        },
+        {
+            "class": "icon_folder_loading",
+            "content_margin": [0,0]
+        }
 ]
 

--- a/sublimeui/mellow.sublime-theme
+++ b/sublimeui/mellow.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/mintchoc.sublime-theme
+++ b/sublimeui/mintchoc.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/mud.sublime-theme
+++ b/sublimeui/mud.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/otakon.sublime-theme
+++ b/sublimeui/otakon.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/pastel.sublime-theme
+++ b/sublimeui/pastel.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/patriot.sublime-theme
+++ b/sublimeui/patriot.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/peacock.sublime-theme
+++ b/sublimeui/peacock.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/peacocks-in-space.sublime-theme
+++ b/sublimeui/peacocks-in-space.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/peel.sublime-theme
+++ b/sublimeui/peel.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/piggy.sublime-theme
+++ b/sublimeui/piggy.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/potpourri.sublime-theme
+++ b/sublimeui/potpourri.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/rainbow.sublime-theme
+++ b/sublimeui/rainbow.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/revelation.sublime-theme
+++ b/sublimeui/revelation.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/shrek.sublime-theme
+++ b/sublimeui/shrek.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/slate.sublime-theme
+++ b/sublimeui/slate.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/slime.sublime-theme
+++ b/sublimeui/slime.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/snappy.sublime-theme
+++ b/sublimeui/snappy.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/solarflare.sublime-theme
+++ b/sublimeui/solarflare.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/sourlick.sublime-theme
+++ b/sublimeui/sourlick.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/spearmint.sublime-theme
+++ b/sublimeui/spearmint.sublime-theme
@@ -1062,7 +1062,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
 
+        {
+            "class": "icon_file_type",
+            "content_margin": [0,0]
+        },
+        {
+            "class": "icon_folder",
+            "content_margin": [0,0]
+        },
+        {
+            "class": "icon_folder_loading",
+            "content_margin": [0,0]
+        }
 ]
 

--- a/sublimeui/stark.sublime-theme
+++ b/sublimeui/stark.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/super.sublime-theme
+++ b/sublimeui/super.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/tonic.sublime-theme
+++ b/sublimeui/tonic.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/tribal.sublime-theme
+++ b/sublimeui/tribal.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/tron.sublime-theme
+++ b/sublimeui/tron.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/turnip.sublime-theme
+++ b/sublimeui/turnip.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/yule.sublime-theme
+++ b/sublimeui/yule.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]

--- a/sublimeui/zacks.sublime-theme
+++ b/sublimeui/zacks.sublime-theme
@@ -1059,6 +1059,22 @@
         "class": "tabset_control",
         "settings": ["spacegray_tabs_xlarge"],
         "tab_height": 40
-    }
+    },
 
+//
+// DISABLE SIDEBAR DEFAULT ICONS
+//
+
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    }
 ]


### PR DESCRIPTION
Hi there :)

As of the latest ST3 build it includes a default set of sidebar icons, this doesn't look very good with the Space Gray theme icons.
I updated the sublimeui pattern to disable it in builds.
I also rebuild all the theme files.

Related to #148
