### PR TITLE
Add missing PHP_PARAMETER to Jetbrains pattern

### DIFF
--- a/build/resources/patterns/jetbrains/jetbrains.pattern
+++ b/build/resources/patterns/jetbrains/jetbrains.pattern
@@ -1140,6 +1140,7 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
+    <option name="PHP_PARAMETER" baseAttributes="DEFAULT_PARAMETER" />
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />


### PR DESCRIPTION
When using any of the Jetbrains themes in PHPStorm, the missing `PHP_PARAMETER` causes all method parameters to use an out-of-place color.

With this change the method parameters will fall back to the usual parameter color.