### PR TITLE
Set jetbrains themes to PyCharm IDE

### DIFF
--- a/jetbrains/arstotzka.icls
+++ b/jetbrains/arstotzka.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Arstotzka" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Arstotzka" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="211f1e" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,7 +15,7 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="516B6B" />
+    <option name="FILESTATUS_MERGED" value="516b6b" />
     <option name="FILESTATUS_MODIFIED" value="a5e3d0" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
     <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="a5e3d0" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,15 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
+      <value />
     </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,7 +82,7 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="BNF_NUMBER">
@@ -106,9 +100,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="211f1e" />
@@ -123,14 +114,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +142,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +153,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +173,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +235,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -296,18 +267,18 @@
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="CSS.NUMBER">
@@ -317,7 +288,7 @@
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +303,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +314,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,18 +333,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="a5e3d0" />
@@ -401,12 +348,15 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="3f3a36" />
+        <option name="FOREGROUND" value="686c70" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,26 +368,23 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="3f3a36" />
+        <option name="FOREGROUND" value="686c70" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -454,9 +401,14 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
@@ -466,17 +418,17 @@
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,12 +440,12 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="3f3a36" />
+        <option name="FOREGROUND" value="686c70" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -508,23 +460,20 @@
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
@@ -534,14 +483,14 @@
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="BACKGROUND" value="211f1e" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +542,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +573,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +586,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +610,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -703,7 +626,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,7 +639,7 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
@@ -726,28 +649,28 @@
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="3f3a36" />
+        <option name="FOREGROUND" value="686c70" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +695,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="516B6B" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="516b6b" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +705,40 @@
         <option name="BACKGROUND" value="211f1e" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +749,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="3f3a36" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +771,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -873,7 +786,7 @@
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +796,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +821,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -976,21 +855,27 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="JSON.INVALID_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="c81414" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +901,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +915,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +928,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1069,6 +935,77 @@
         <option name="FOREGROUND" value="a5e3d0" />
       </value>
     </option>
+    <option name="MULTIMARKDOWN.ABBREVIATION">
+      <value>
+        <option name="FOREGROUND" value="513f9c" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.DEFINITION_TERM">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.HEADER_ATX_MARKER">
+      <value>
+        <option name="FOREGROUND" value="513f9c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HEADER_SETEXT_MARKER">
+      <value>
+        <option name="FOREGROUND" value="513f9c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HRULE">
+      <value>
+        <option name="FOREGROUND" value="513f9c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HTML_BLOCK" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" />
+    <option name="MULTIMARKDOWN.INLINE_HTML" baseAttributes="MULTIMARKDOWN.HTML_BLOCK" />
+    <option name="MULTIMARKDOWN.LINE_BREAK_SPACES" baseAttributes="DEFAULT_INVALID_STRING_ESCAPE" />
+    <option name="MULTIMARKDOWN.QUOTE" baseAttributes="DEFAULT_STRING" />
+    <option name="MULTIMARKDOWN.SPECIAL_TEXT" baseAttributes="DEFAULT_VALID_STRING_ESCAPE" />
+    <option name="MULTIMARKDOWN.TABLE">
+      <value>
+        <option name="FOREGROUND" value="513f9c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CAPTION">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_REVEN_CEVEN">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_REVEN_CODD">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_RODD_CEVEN">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_ROW_EVEN">
+      <value>
+        <option name="FOREGROUND" value="513f9c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_ROW_ODD">
+      <value>
+        <option name="FOREGROUND" value="513f9c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TASK_ITEM_MARKER">
+      <value>
+        <option name="FOREGROUND" value="513f9c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.VERBATIM" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" />
+    <option name="MULTIMARKDOWN.WIKI_LINK_REF" baseAttributes="MULTIMARKDOWN.WIKI_LINK" />
+    <option name="MULTIMARKDOWN.WIKI_LINK_REF_ANCHOR" baseAttributes="MULTIMARKDOWN.WIKI_LINK_REF" />
+    <option name="MULTIMARKDOWN.WIKI_LINK_TEXT" baseAttributes="MULTIMARKDOWN.WIKI_LINK_REF" />
     <option name="Map key">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1088,18 +1025,17 @@
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="OC.NUMBER">
@@ -1110,12 +1046,11 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="OC.STRING">
@@ -1126,17 +1061,16 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,17 +1082,17 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
@@ -1171,17 +1105,14 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
@@ -1191,7 +1122,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,31 +1129,30 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
+    <option name="PY.DECORATOR" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="c81414" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.KEYWORD_ARGUMENT">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="9595" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="4cd6a3" />
+        <option name="FOREGROUND" value="c81414" />
         <option name="BACKGROUND" value="211f1e" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1231,33 +1160,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1190,16 @@
         <option name="BACKGROUND" value="211f1e" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,7 +1215,7 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1491,31 +1237,16 @@
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,13 +1259,13 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1543,15 +1274,15 @@
         <option name="FOREGROUND" value="a5e3d0" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
+    <option name="TAG">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="6d689c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,7 +1293,7 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
         <option name="BACKGROUND" value="211f1e" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
@@ -1584,7 +1315,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1345,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5e3d0" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1369,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="A2A797" />
+        <option name="EFFECT_COLOR" value="a2a797" />
+        <option name="ERROR_STRIPE_COLOR" value="a2a797" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="A2A797" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,7 +1398,7 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
@@ -1687,15 +1406,9 @@
         <option name="FOREGROUND" value="a5e3d0" />
       </value>
     </option>
-    <option name="XML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="3f3a36" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="XML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="6d9cbe" />
+        <option name="FOREGROUND" value="6d689c" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,20 +1418,17 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1735,12 +1445,12 @@
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="516B6B" />
+        <option name="FOREGROUND" value="516b6b" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1792,24 +1502,16 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
+    <option name="Yaml Specials">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="6d689c" />
       </value>
     </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="A2A797" />
+        <option name="FOREGROUND" value="a2a797" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/azure.icls
+++ b/jetbrains/azure.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Azure" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Azure" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="181d26" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -25,7 +24,7 @@
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
     <option name="FILESTATUS_modifiedOutside" value="64aeb3" />
-    <option name="GUTTER_BACKGROUND" value="181D26" />
+    <option name="GUTTER_BACKGROUND" value="181d26" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,15 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
+      <value />
     </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="508aaa" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -106,12 +100,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +114,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="52708b" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +142,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +153,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +173,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +212,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +233,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -335,22 +306,10 @@
         <option name="FOREGROUND" value="508aaa" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
@@ -374,18 +333,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="64aeb3" />
@@ -400,9 +347,6 @@
       <value>
         <option name="FOREGROUND" value="4646f1" />
       </value>
-    </option>
-    <option name="Class">
-      <value />
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -427,9 +371,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
         <option name="FOREGROUND" value="52708b" />
@@ -453,6 +394,12 @@
     </option>
     <option name="DEFAULT_DOT">
       <value />
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
@@ -481,7 +428,7 @@
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="dee3ec" />
+        <option name="FOREGROUND" value="c81414" />
         <option name="EFFECT_COLOR" value="c81414" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
@@ -514,9 +461,6 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
         <option name="FOREGROUND" value="52708b" />
@@ -535,7 +479,7 @@
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
         <option name="FOREGROUND" value="508aaa" />
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
@@ -547,7 +491,7 @@
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +504,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +537,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="c81414" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +568,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +581,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +592,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +605,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -742,7 +660,7 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="6AB0A3" />
+        <option name="FOREGROUND" value="6ab0a3" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
@@ -773,17 +691,14 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="52708b" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +709,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -840,9 +751,6 @@
       <value>
         <option name="FOREGROUND" value="414d62" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -886,21 +794,10 @@
         <option name="FOREGROUND" value="508aaa" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +816,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="52708b" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +864,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +889,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +903,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +916,135 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="64aeb3" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.ABBREVIATION">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.DEFINITION_TERM">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.HEADER_ATX_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HEADER_SETEXT_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HRULE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HTML_BLOCK">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.IMAGE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.INLINE_HTML">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.LINE_BREAK_SPACES">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.MAIL_LINK">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="EFFECT_COLOR" value="7100c8" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.QUOTE">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.REFERENCE_IMAGE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.SMARTS">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.SPECIAL_TEXT">
+      <value>
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TABLE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CAPTION">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_REVEN_CEVEN">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_REVEN_CODD">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_RODD_CEVEN">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_ROW_EVEN">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_ROW_ODD">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TASK_ITEM_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.VERBATIM">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.WIKI_LINK_REF">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+        <option name="EFFECT_COLOR" value="ba" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.WIKI_LINK_REF_ANCHOR">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.WIKI_LINK_TEXT">
+      <value>
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="Map key">
@@ -1094,7 +1072,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1110,7 +1087,6 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1126,7 +1102,6 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1143,7 +1118,7 @@
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
@@ -1164,7 +1139,7 @@
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="64aeb3" />
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
@@ -1180,9 +1155,6 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
         <option name="FOREGROUND" value="64aeb3" />
@@ -1191,7 +1163,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,21 +1170,15 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="6d689c" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
+    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
@@ -1224,7 +1189,7 @@
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
@@ -1235,20 +1200,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="508aaa" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1211,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="181D26" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1232,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1503,21 +1285,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
     <option name="Static field">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1543,9 +1310,9 @@
         <option name="FOREGROUND" value="64aeb3" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
+    <option name="TAG">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="6d689c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1563,13 +1330,13 @@
     <option name="TEXT">
       <value>
         <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1351,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1381,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="508aaa" />
@@ -1632,14 +1392,9 @@
         <option name="FOREGROUND" value="64aeb3" />
       </value>
     </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1655,20 +1410,20 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="508aaa" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="508aaa" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="181D26" />
+        <option name="BACKGROUND" value="181d26" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1687,17 +1442,6 @@
         <option name="FOREGROUND" value="64aeb3" />
       </value>
     </option>
-    <option name="XML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="414d62" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1707,9 +1451,6 @@
       <value>
         <option name="FOREGROUND" value="ffffff" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1740,7 +1481,7 @@
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="6AB0A3" />
+        <option name="FOREGROUND" value="6ab0a3" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1792,15 +1533,9 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
+    <option name="Yaml Specials">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="6d689c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1812,4 +1547,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/bold.icls
+++ b/jetbrains/bold.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Bold" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Bold" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="161a1f" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,15 +15,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="F0624B" />
-    <option name="FILESTATUS_MODIFIED" value="F7A21B" />
+    <option name="FILESTATUS_MERGED" value="f0624b" />
+    <option name="FILESTATUS_MODIFIED" value="f7a21b" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="F7A21B" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="F7A21B" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f7a21b" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="f7a21b" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="F7A21B" />
+    <option name="FILESTATUS_modifiedOutside" value="f7a21b" />
     <option name="GUTTER_BACKGROUND" value="2a2626" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,15 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
+      <value />
     </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +82,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +99,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +114,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +142,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +153,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +173,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +235,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +252,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +262,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +303,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +314,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +333,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -400,9 +347,6 @@
       <value>
         <option name="FOREGROUND" value="4646f1" />
       </value>
-    </option>
-    <option name="Class">
-      <value />
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +362,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,14 +395,20 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
@@ -476,19 +423,19 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="dee3ec" />
+        <option name="FOREGROUND" value="c81414" />
         <option name="EFFECT_COLOR" value="c81414" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,45 +450,42 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="BACKGROUND" value="2a2626" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +537,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +568,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +581,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +605,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,23 +634,17 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
-      </value>
-    </option>
-    <option name="HTML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="534b4b" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -742,12 +654,12 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="3D8E91" />
+        <option name="FOREGROUND" value="3d8e91" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +684,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="F0624B" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="f0624b" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +694,40 @@
         <option name="BACKGROUND" value="2a2626" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +738,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="534b4b" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +760,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +770,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +785,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +810,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +846,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +883,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +897,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +910,116 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.ABBREVIATION">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.DEFINITION_TERM">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.HEADER_ATX_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HEADER_SETEXT_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HRULE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HTML_BLOCK">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.IMAGE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.INLINE_HTML">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.LINE_BREAK_SPACES">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.MAIL_LINK">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="EFFECT_COLOR" value="7100c8" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.QUOTE">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.SMARTS">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.SPECIAL_TEXT">
+      <value>
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CAPTION">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_REVEN_CEVEN">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_REVEN_CODD">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_RODD_CEVEN">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_ROW_EVEN">
+      <value>
+        <option name="FOREGROUND" value="4f0885" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TASK_ITEM_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.VERBATIM" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" />
+    <option name="MULTIMARKDOWN.WIKI_LINK_REF">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+        <option name="EFFECT_COLOR" value="ba" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.WIKI_LINK_REF_ANCHOR">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="BACKGROUND" value="e6ffed" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.WIKI_LINK_TEXT">
+      <value>
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,60 +1036,57 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,7 +1098,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1163,7 +1113,7 @@
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
         <option name="BACKGROUND" value="2a2626" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1171,7 +1121,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1180,18 +1130,14 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1145,15 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
+    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
+    <option name="PY.DECORATOR" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1167,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1197,16 @@
         <option name="BACKGROUND" value="2a2626" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,53 +1222,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1266,30 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
+    <option name="TAG">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="6d689c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1322,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1352,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1376,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="F0624B" />
+        <option name="EFFECT_COLOR" value="f0624b" />
+        <option name="ERROR_STRIPE_COLOR" value="f0624b" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="F0624B" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1405,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="534b4b" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1708,39 +1429,36 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="3D8E91" />
+        <option name="FOREGROUND" value="3d8e91" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1470,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1485,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1510,17 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
+    <option name="Yaml Specials">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="6d689c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="F0624B" />
+        <option name="FOREGROUND" value="f0624b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/boxuk.icls
+++ b/jetbrains/boxuk.icls
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Box UK" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Box UK" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
@@ -16,7 +15,7 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="019d76" />
+    <option name="FILESTATUS_MERGED" value="19d76" />
     <option name="FILESTATUS_MODIFIED" value="15b8ae" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
     <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="15b8ae" />
@@ -33,12 +32,12 @@
     <option name="NOTIFICATION_BACKGROUND" value="3d1a11" />
     <option name="READONLY_FRAGMENT_BACKGROUND" value="" />
     <option name="RECURSIVE_CALL_ATTRIBUTES" value="574300" />
-    <option name="RIGHT_MARGIN_COLOR" value="323232" />
+    <option name="RIGHT_MARGIN_COLOR" value="686c70" />
     <option name="SELECTED_INDENT_GUIDE" value="505050" />
     <option name="SELECTED_TEARLINE_COLOR" value="787878" />
-    <option name="SELECTION_BACKGROUND" value="161a1f" />
+    <option name="SELECTION_BACKGROUND" value="b7c481" />
     <option name="SELECTION_FOREGROUND" value="" />
-    <option name="TEARLINE_COLOR" value="303134" />
+    <option name="TEARLINE_COLOR" value="686c70" />
     <option name="WHITESPACES" value="505050" />
   </colors>
   <attributes>
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,15 +59,11 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
+      <value />
     </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BASH.INTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="b0c95" />
-      </value>
+      <value />
     </option>
     <option name="BNF_EXTERNAL">
       <value>
@@ -88,7 +77,7 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="BNF_NUMBER">
@@ -106,9 +95,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="ffffff" />
@@ -123,14 +109,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="019d76" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +137,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +148,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +168,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +230,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -296,18 +262,18 @@
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="CSS.NUMBER">
@@ -317,7 +283,7 @@
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +298,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +309,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,18 +328,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="15b8ae" />
@@ -401,9 +343,6 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
-    </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
         <option name="FOREGROUND" value="b8b6b1" />
@@ -418,21 +357,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -456,7 +392,7 @@
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
@@ -476,7 +412,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +424,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -508,23 +444,20 @@
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
@@ -534,14 +467,14 @@
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="BACKGROUND" value="ffffff" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +526,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +557,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +570,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +594,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,7 +623,7 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
@@ -732,7 +639,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -742,12 +649,12 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +679,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="019d76" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="19d76" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +689,40 @@
         <option name="BACKGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +733,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="b8b6b1" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +755,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -873,7 +770,7 @@
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +780,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +805,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="019d76" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +841,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +878,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +892,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +905,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1088,18 +931,17 @@
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="OC.NUMBER">
@@ -1110,12 +952,11 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="OC.STRING">
@@ -1126,17 +967,16 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,7 +988,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1171,7 +1011,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1179,9 +1019,6 @@
       <value>
         <option name="FOREGROUND" value="414f5c" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
@@ -1191,7 +1028,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1035,19 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="c81414" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1061,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1091,16 @@
         <option name="BACKGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,7 +1116,7 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1491,31 +1138,16 @@
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,13 +1160,13 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1543,15 +1175,9 @@
         <option name="FOREGROUND" value="15b8ae" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1210,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1240,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="15b8ae" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1264,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="017c9d" />
+        <option name="EFFECT_COLOR" value="17c9d" />
+        <option name="ERROR_STRIPE_COLOR" value="17c9d" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="017c9d" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,7 +1293,7 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
@@ -1693,11 +1307,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1708,17 +1317,14 @@
         <option name="FOREGROUND" value="414f5c" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1735,12 +1341,12 @@
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="019d76" />
+        <option name="FOREGROUND" value="19d76" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1792,24 +1398,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="017c9d" />
+        <option name="FOREGROUND" value="17c9d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/carbonight.icls
+++ b/jetbrains/carbonight.icls
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Carbonight" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Carbonight" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
@@ -16,7 +15,7 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="8C8C8C" />
+    <option name="FILESTATUS_MERGED" value="8c8c8c" />
     <option name="FILESTATUS_MODIFIED" value="ffffff" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
     <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="ffffff" />
@@ -25,7 +24,7 @@
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
     <option name="FILESTATUS_modifiedOutside" value="ffffff" />
-    <option name="GUTTER_BACKGROUND" value="2E2C2B" />
+    <option name="GUTTER_BACKGROUND" value="2e2c2b" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,15 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
+      <value />
     </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="eeeeee" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,7 +82,7 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="BNF_NUMBER">
@@ -106,12 +100,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +114,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +142,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +153,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +173,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +212,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +233,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -296,7 +267,7 @@
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
@@ -307,7 +278,7 @@
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="CSS.NUMBER">
@@ -317,7 +288,7 @@
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -335,27 +306,15 @@
         <option name="FOREGROUND" value="eeeeee" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,18 +333,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
@@ -401,12 +348,9 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
-    </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="423F3D" />
+        <option name="FOREGROUND" value="686c70" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,32 +362,35 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="423F3D" />
+        <option name="FOREGROUND" value="686c70" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
       <value>
         <option name="FOREGROUND" value="5c5856" />
         <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
+      <value>
+        <option name="FOREGROUND" value="686c70" />
+        <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="DEFAULT_DOC_MARKUP">
@@ -453,6 +400,12 @@
     </option>
     <option name="DEFAULT_DOT">
       <value />
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
@@ -466,22 +419,22 @@
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="dee3ec" />
+        <option name="FOREGROUND" value="c81414" />
         <option name="EFFECT_COLOR" value="c81414" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
@@ -493,7 +446,7 @@
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="423F3D" />
+        <option name="FOREGROUND" value="686c70" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -514,40 +467,37 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="a8c023" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
         <option name="FOREGROUND" value="eeeeee" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +510,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +543,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="c81414" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +574,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +587,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +598,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +611,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +627,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,7 +640,7 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
@@ -724,30 +648,24 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="HTML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="423F3D" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="C4C4C4" />
+        <option name="FOREGROUND" value="c4c4c4" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +690,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="8C8C8C" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="8c8c8c" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -838,11 +749,8 @@
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="423F3D" />
+        <option name="FOREGROUND" value="423f3d" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -886,21 +794,10 @@
         <option name="FOREGROUND" value="eeeeee" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +816,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +864,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +889,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +903,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +916,120 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.ABBREVIATION">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.ATX_HEADER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.DEFINITION_TERM">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.HEADER_SETEXT_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HRULE" baseAttributes="MULTIMARKDOWN.ATX_HEADER" />
+    <option name="MULTIMARKDOWN.HTML_BLOCK" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" />
+    <option name="MULTIMARKDOWN.IMAGE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.INLINE_HTML">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.LINE_BREAK_SPACES">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.MAIL_LINK">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="EFFECT_COLOR" value="7100c8" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.QUOTE">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.SMARTS">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.SPECIAL_TEXT">
+      <value>
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TABLE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CAPTION">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_REVEN_CEVEN">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_REVEN_CODD">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_RODD_CEVEN">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_ROW_EVEN">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_ROW_ODD">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TASK_ITEM_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.VERBATIM" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" />
+    <option name="MULTIMARKDOWN.WIKI_LINK_REF">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+        <option name="EFFECT_COLOR" value="ba" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.WIKI_LINK_REF_ANCHOR">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.WIKI_LINK_TEXT">
+      <value>
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,7 +1046,7 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
@@ -1094,7 +1057,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1104,13 +1066,12 @@
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1126,7 +1087,6 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1136,14 +1096,14 @@
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
@@ -1153,18 +1113,18 @@
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
@@ -1177,11 +1137,8 @@
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
@@ -1191,7 +1148,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,21 +1155,11 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
+    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
+    <option name="PY.DECORATOR" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
@@ -1224,7 +1170,7 @@
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
@@ -1235,20 +1181,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="eeeeee" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1192,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1213,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1475,7 +1238,7 @@
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
     </option>
     <option name="SQL_STRING">
@@ -1491,31 +1254,16 @@
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,13 +1276,13 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1543,9 +1291,9 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
+    <option name="TAG">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="6d689c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1310,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="FOREGROUND" value="b0b0b0" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1332,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1362,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="eeeeee" />
@@ -1632,14 +1373,9 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1655,20 +1391,20 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="eeeeee" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="eeeeee" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,7 +1415,7 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
@@ -1689,13 +1425,14 @@
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="423F3D" />
+        <option name="FOREGROUND" value="423f3d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="XML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="6d9cbe" />
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,11 +1442,8 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1724,7 +1458,7 @@
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
     </option>
     <option name="XPATH.STRING">
@@ -1735,18 +1469,18 @@
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="8C8C8C" />
+        <option name="FOREGROUND" value="8c8c8c" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="C4C4C4" />
+        <option name="FOREGROUND" value="c4c4c4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="423F3D" />
+        <option name="FOREGROUND" value="423f3d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1772,7 +1506,7 @@
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="B0B0B0" />
+        <option name="FOREGROUND" value="b0b0b0" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,15 +1526,9 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
+    <option name="Yaml Specials">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="6d689c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1812,4 +1540,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/chocolate.icls
+++ b/jetbrains/chocolate.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Chocolate" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Chocolate" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="150f08" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,15 +15,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="CCB697" />
-    <option name="FILESTATUS_MODIFIED" value="F7A21B" />
+    <option name="FILESTATUS_MERGED" value="ccb697" />
+    <option name="FILESTATUS_MODIFIED" value="f7a21b" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="F7A21B" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="F7A21B" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f7a21b" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="f7a21b" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="F7A21B" />
+    <option name="FILESTATUS_modifiedOutside" value="f7a21b" />
     <option name="GUTTER_BACKGROUND" value="150f08" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,15 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
+      <value />
     </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +82,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +99,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +114,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +142,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +153,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +173,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +235,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +252,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +262,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +303,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="B99768" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +314,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +333,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -400,9 +347,6 @@
       <value>
         <option name="FOREGROUND" value="4646f1" />
       </value>
-    </option>
-    <option name="Class">
-      <value />
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +362,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,14 +395,20 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
@@ -476,19 +423,19 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="dee3ec" />
+        <option name="FOREGROUND" value="c81414" />
         <option name="EFFECT_COLOR" value="c81414" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,45 +450,42 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
         <option name="BACKGROUND" value="150f08" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +537,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="c81414" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +568,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +581,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +605,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,12 +634,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,7 +650,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -742,12 +660,12 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="8B6E46" />
+        <option name="FOREGROUND" value="8b6e46" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +690,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="CCB697" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="ccb697" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +700,40 @@
         <option name="BACKGROUND" value="150f08" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +744,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="795431" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +766,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +776,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +791,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="B99768" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +816,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +852,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +889,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +903,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,14 +916,88 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
+    <option name="MULTIMARKDOWN.ABBREVIATION">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.DEFINITION_TERM">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.HEADER_ATX_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HEADER_SETEXT_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HRULE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HTML_BLOCK" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" />
+    <option name="MULTIMARKDOWN.IMAGE">
+      <value>
+        <option name="FOREGROUND" value="a8c023" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.INLINE_HTML">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.LINE_BREAK_SPACES">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.MAIL_LINK" baseAttributes="MULTIMARKDOWN.AUTO_LINK" />
+    <option name="MULTIMARKDOWN.QUOTE">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.SMARTS">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.SPECIAL_TEXT">
+      <value>
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CAPTION">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_REVEN_CEVEN">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_REVEN_CODD">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_RODD_CEVEN">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_ROW_EVEN">
+      <value>
+        <option name="FOREGROUND" value="4f0885" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.VERBATIM">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.WIKI_LINK_REF" baseAttributes="MULTIMARKDOWN.WIKI_LINK" />
+    <option name="MULTIMARKDOWN.WIKI_LINK_REF_ANCHOR" baseAttributes="MULTIMARKDOWN.WIKI_LINK_REF" />
+    <option name="MULTIMARKDOWN.WIKI_LINK_TEXT" baseAttributes="MULTIMARKDOWN.WIKI_LINK_REF" />
     <option name="Map key">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1083,60 +1012,57 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,7 +1074,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1163,7 +1089,7 @@
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
         <option name="BACKGROUND" value="150f08" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1171,7 +1097,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1180,18 +1106,14 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1121,17 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
+    <option name="PY.DECORATOR" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.KEYWORD_ARGUMENT">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="9595" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1145,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="B99768" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="b99768" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1175,16 @@
         <option name="BACKGROUND" value="150f08" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,53 +1200,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1244,30 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
+    <option name="TAG">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="6d689c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1300,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1330,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1354,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="B99768" />
+        <option name="EFFECT_COLOR" value="b99768" />
+        <option name="ERROR_STRIPE_COLOR" value="b99768" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="B99768" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1383,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="795431" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1708,39 +1407,36 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="CCB697" />
+        <option name="FOREGROUND" value="ccb697" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="8B6E46" />
+        <option name="FOREGROUND" value="8b6e46" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1448,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1463,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1488,17 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
+    <option name="Yaml Specials">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="6d689c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="B99768" />
+        <option name="FOREGROUND" value="b99768" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/crisp.icls
+++ b/jetbrains/crisp.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Crisp" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Crisp" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="221a22" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,15 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
+      <value />
     </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -106,9 +100,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="221a22" />
@@ -123,14 +114,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="765478" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +142,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +153,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +173,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +235,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -301,7 +272,7 @@
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -332,19 +303,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -374,18 +333,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="fc9a0f" />
@@ -401,12 +348,9 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
-    </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="574457" />
+        <option name="FOREGROUND" value="947494" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -427,9 +371,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
         <option name="FOREGROUND" value="765478" />
@@ -437,13 +378,19 @@
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="574457" />
+        <option name="FOREGROUND" value="947494" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
       <value>
         <option name="FOREGROUND" value="776377" />
         <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="DEFAULT_DOC_MARKUP">
@@ -454,9 +401,15 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
@@ -481,19 +434,20 @@
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="dee3ec" />
-        <option name="EFFECT_COLOR" value="c81414" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="FOREGROUND" value="c81414" />
+        <option name="BACKGROUND" value="221a22" />
+        <option name="ERROR_STRIPE_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="574457" />
+        <option name="FOREGROUND" value="947494" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -508,13 +462,10 @@
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
-      <value />
-    </option>
-    <option name="DEFAULT_SEMICOLON">
       <value />
     </option>
     <option name="DEFAULT_STATIC_FIELD">
@@ -534,7 +485,7 @@
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
         <option name="BACKGROUND" value="221a22" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
@@ -593,15 +544,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="c81414" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +575,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +588,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +612,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -722,12 +647,6 @@
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
         <option name="FOREGROUND" value="fc9a0f" />
-      </value>
-    </option>
-    <option name="HTML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="574457" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
@@ -773,17 +692,14 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="765478" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
         <option name="BACKGROUND" value="221a22" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +710,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -833,16 +745,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="574457" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +767,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -873,7 +782,7 @@
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +792,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +817,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="765478" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +853,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +890,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +904,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +917,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1069,6 +924,94 @@
         <option name="FOREGROUND" value="fc9a0f" />
       </value>
     </option>
+    <option name="MULTIMARKDOWN.ABBREVIATION">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.DEFINITION_TERM">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.HEADER_ATX_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HEADER_SETEXT_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HRULE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.HTML_BLOCK" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" />
+    <option name="MULTIMARKDOWN.IMAGE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.INLINE_HTML">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.LINE_BREAK_SPACES">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.MAIL_LINK">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="EFFECT_COLOR" value="7100c8" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.QUOTE">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.SMARTS">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.SPECIAL_TEXT">
+      <value>
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CAPTION">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_REVEN_CEVEN">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_REVEN_CODD">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_CELL_RODD_CEVEN">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.TABLE_ROW_EVEN">
+      <value>
+        <option name="FOREGROUND" value="4f0885" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.TASK_ITEM_MARKER">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MULTIMARKDOWN.VERBATIM">
+      <value />
+    </option>
+    <option name="MULTIMARKDOWN.WIKI_LINK_REF" baseAttributes="MULTIMARKDOWN.WIKI_LINK" />
+    <option name="MULTIMARKDOWN.WIKI_LINK_REF_ANCHOR" baseAttributes="MULTIMARKDOWN.WIKI_LINK_REF" />
+    <option name="MULTIMARKDOWN.WIKI_LINK_TEXT" baseAttributes="MULTIMARKDOWN.WIKI_LINK_REF" />
     <option name="Map key">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1088,18 +1031,17 @@
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="OC.NUMBER">
@@ -1110,12 +1052,11 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="OC.STRING">
@@ -1126,12 +1067,11 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
@@ -1148,7 +1088,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1171,7 +1111,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1179,9 +1119,6 @@
       <value>
         <option name="FOREGROUND" value="ffffff" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
@@ -1191,7 +1128,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1135,24 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
+    <option name="PY.DECORATOR" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="c81414" />
+        <option name="ERROR_STRIPE_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.KEYWORD_ARGUMENT">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="b7c481" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1166,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="fc6a0f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1196,16 @@
         <option name="BACKGROUND" value="221a22" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,7 +1221,7 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1503,21 +1255,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
     <option name="Static field">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1543,15 +1280,15 @@
         <option name="FOREGROUND" value="fc9a0f" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
+    <option name="TAG">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="6d689c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1321,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1351,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="fc9a0f" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1375,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="FC6A0F" />
+        <option name="EFFECT_COLOR" value="fc6a0f" />
+        <option name="ERROR_STRIPE_COLOR" value="fc6a0f" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="FC6A0F" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1693,11 +1418,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1708,17 +1428,14 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1792,24 +1509,17 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
+    <option name="Yaml Specials">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="6d689c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="FC6A0F" />
+        <option name="FOREGROUND" value="fc6a0f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/darkside.icls
+++ b/jetbrains/darkside.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Darkside" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Darkside" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="222324" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,15 +15,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="E8341C" />
-    <option name="FILESTATUS_MODIFIED" value="F2D42C" />
+    <option name="FILESTATUS_MERGED" value="e8341c" />
+    <option name="FILESTATUS_MODIFIED" value="f2d42c" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="F2D42C" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="F2D42C" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f2d42c" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="f2d42c" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="F2D42C" />
+    <option name="FILESTATUS_modifiedOutside" value="f2d42c" />
     <option name="GUTTER_BACKGROUND" value="222324" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,27 +52,22 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
-        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_COLOR" value="ff8e27" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
+      <value />
     </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +82,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +99,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +114,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +142,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +153,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +173,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +235,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +252,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +262,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +303,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +314,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +333,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +348,9 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
-    </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="494B4D" />
+        <option name="FOREGROUND" value="494b4d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,26 +362,23 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="494B4D" />
+        <option name="FOREGROUND" value="494b4d" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -456,44 +397,44 @@
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="dee3ec" />
-        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_COLOR" value="ff8e27" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="494B4D" />
+        <option name="FOREGROUND" value="494b4d" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,45 +444,42 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
         <option name="BACKGROUND" value="222324" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +531,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +562,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +575,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +599,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -703,7 +615,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,38 +628,38 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="c57633" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="494B4D" />
+        <option name="FOREGROUND" value="494b4d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="8f9c64" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="1CC3E8" />
+        <option name="FOREGROUND" value="1cc3e8" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +684,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="E8341C" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="e8341c" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +694,40 @@
         <option name="BACKGROUND" value="222324" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +738,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="494B4D" />
+        <option name="FOREGROUND" value="494b4d" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +760,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +770,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +785,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +810,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -976,21 +844,32 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="JSON.INVALID_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f21515" />
+        <option name="EFFECT_COLOR" value="ff8e27" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JSON.VALID_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="c57633" />
+      </value>
+    </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +895,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,12 +909,14 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
+      <value />
+    </option>
+    <option name="MARKDOWN_HEADER_LEVEL_1">
       <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
@@ -1061,12 +927,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,60 +948,57 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="8E69C9" />
+        <option name="FOREGROUND" value="8e69c9" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="8E69C9" />
+        <option name="FOREGROUND" value="8e69c9" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,22 +1010,22 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
         <option name="BACKGROUND" value="222324" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1171,27 +1033,23 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1057,22 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
+    <option name="PY.DECORATOR" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="c81414" />
+        <option name="EFFECT_COLOR" value="ff8e27" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1086,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="f08d24" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1116,16 @@
         <option name="BACKGROUND" value="222324" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,53 +1141,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="8E69C9" />
+        <option name="FOREGROUND" value="8e69c9" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1185,30 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
+    <option name="TAG">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="6d689c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,7 +1219,7 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
         <option name="BACKGROUND" value="222324" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
@@ -1584,7 +1241,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1271,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1295,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="F08D24" />
+        <option name="EFFECT_COLOR" value="f08d24" />
+        <option name="ERROR_STRIPE_COLOR" value="f08d24" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="F08D24" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1324,24 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="494B4D" />
+        <option name="FOREGROUND" value="494b4d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="XML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="6d9cbe" />
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,59 +1351,56 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="8E69C9" />
+        <option name="FOREGROUND" value="8e69c9" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="E8341C" />
+        <option name="FOREGROUND" value="e8341c" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="1CC3E8" />
+        <option name="FOREGROUND" value="1cc3e8" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="494B4D" />
+        <option name="FOREGROUND" value="494b4d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1410,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="F2D42C" />
+        <option name="FOREGROUND" value="f2d42c" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="8E69C9" />
+        <option name="FOREGROUND" value="8e69c9" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1435,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="F08D24" />
+        <option name="FOREGROUND" value="f08d24" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/earthsong.icls
+++ b/jetbrains/earthsong.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Earthsong" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Earthsong" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="36312c" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="DB784D" />
-    <option name="FILESTATUS_MODIFIED" value="F8BB39" />
+    <option name="FILESTATUS_MERGED" value="db784d" />
+    <option name="FILESTATUS_MODIFIED" value="f8bb39" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="F8BB39" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="F8BB39" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f8bb39" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="f8bb39" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="F8BB39" />
-    <option name="GUTTER_BACKGROUND" value="36312C" />
+    <option name="FILESTATUS_modifiedOutside" value="f8bb39" />
+    <option name="GUTTER_BACKGROUND" value="36312c" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,15 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
+      <value />
     </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +82,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +100,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +114,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +142,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +153,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +173,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +212,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +233,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +252,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +262,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +303,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +333,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +348,14 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,26 +367,23 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -454,29 +400,30 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY" baseAttributes="DEFAULT_IDENTIFIER" />
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="EBD1B7" />
+        <option name="FOREGROUND" value="ebd1b7" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="EBD1B7" />
+        <option name="FOREGROUND" value="ebd1b7" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,12 +435,12 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,51 +450,48 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="FOREGROUND" value="db784d" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +504,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +537,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +568,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +581,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +605,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +621,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="EBD1B7" />
+        <option name="FOREGROUND" value="ebd1b7" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,38 +634,38 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="EBD1B7" />
+        <option name="FOREGROUND" value="ebd1b7" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="95CC5E" />
+        <option name="FOREGROUND" value="95cc5e" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +690,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="DB784D" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="db784d" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +744,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +766,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +776,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +791,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +816,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +852,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +889,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +903,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +916,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +937,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="EBD1B7" />
+        <option name="FOREGROUND" value="ebd1b7" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="EBD1B7" />
+        <option name="FOREGROUND" value="ebd1b7" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="FOREGROUND" value="f8bb39" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="EBD1B7" />
+        <option name="FOREGROUND" value="ebd1b7" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1046,42 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
+    <option name="PY.DECORATOR" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="c82e61" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1090,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1111,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1130,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1174,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1202,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="EBD1B7" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="FOREGROUND" value="ebd1b7" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1224,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1254,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1278,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="DB784D" />
+        <option name="EFFECT_COLOR" value="db784d" />
+        <option name="ERROR_STRIPE_COLOR" value="db784d" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="DB784D" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1307,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,59 +1328,56 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="EBD1B7" />
+        <option name="FOREGROUND" value="ebd1b7" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="95CC5E" />
+        <option name="FOREGROUND" value="95cc5e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1387,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1412,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/freshcut.icls
+++ b/jetbrains/freshcut.icls
@@ -1,14 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="FreshCut" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="FreshCut" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <font>
+    <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
+    <option name="EDITOR_FONT_SIZE" value="14" />
+  </font>
+  <font>
+    <option name="EDITOR_FONT_NAME" value="DejaVu Sans Mono" />
+    <option name="EDITOR_FONT_SIZE" value="14" />
+  </font>
+  <option name="CONSOLE_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="2f3030" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,7 +22,7 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="00A8C6" />
+    <option name="FILESTATUS_MERGED" value="a8c6" />
     <option name="FILESTATUS_MODIFIED" value="e9ee00" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
     <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="e9ee00" />
@@ -25,7 +31,7 @@
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
     <option name="FILESTATUS_modifiedOutside" value="e9ee00" />
-    <option name="GUTTER_BACKGROUND" value="2F3030" />
+    <option name="GUTTER_BACKGROUND" value="2f3030" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -36,7 +42,7 @@
     <option name="RIGHT_MARGIN_COLOR" value="323232" />
     <option name="SELECTED_INDENT_GUIDE" value="505050" />
     <option name="SELECTED_TEARLINE_COLOR" value="787878" />
-    <option name="SELECTION_BACKGROUND" value="161a1f" />
+    <option name="SELECTION_BACKGROUND" value="5b5b5b" />
     <option name="SELECTION_FOREGROUND" value="" />
     <option name="TEARLINE_COLOR" value="303134" />
     <option name="WHITESPACES" value="505050" />
@@ -49,14 +55,13 @@
     </option>
     <option name="ANNOTATION_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="bbb529" />
+        <option name="FOREGROUND" value="aedf34" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
+    <option name="ANONYMOUS_CLASS_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ddff" />
       </value>
     </option>
     <option name="BAD_CHARACTER">
@@ -66,16 +71,9 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
+      <value />
     </option>
-    <option name="BASH.INTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="b0c95" />
-      </value>
-    </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BNF_EXTERNAL">
       <value>
         <option name="FONT_TYPE" value="2" />
@@ -88,7 +86,7 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="BNF_NUMBER">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="393a33" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,18 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="CLASS_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="ddff" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +151,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +162,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +182,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +221,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -258,12 +244,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -277,6 +257,11 @@
     <option name="CONSOLE_YELLOW_OUTPUT">
       <value>
         <option name="FOREGROUND" value="cdcd00" />
+      </value>
+    </option>
+    <option name="CONSTRUCTOR_DECLARATION_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="aedf34" />
       </value>
     </option>
     <option name="CSS.COLOR">
@@ -296,18 +281,18 @@
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="CSS.NUMBER">
@@ -317,7 +302,7 @@
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +317,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="c8d7e8" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,18 +347,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="e9ee00" />
@@ -401,8 +362,10 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="fd971f" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +381,24 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="4ecdc4" />
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_COMMA">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="aedf34" />
+      </value>
     </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,77 +420,91 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="e9ee00" />
+        <option name="FOREGROUND" value="aedf34" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="dee3ec" />
-        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="FOREGROUND" value="ff260f" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="737b84" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
       <value>
-        <option name="FOREGROUND" value="bbb529" />
+        <option name="FOREGROUND" value="aedf34" />
       </value>
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="e9ee00" />
+        <option name="FOREGROUND" value="aedf34" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="a8c6" />
+      </value>
+    </option>
+    <option name="DEFAULT_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="fd971f" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
+    <option name="DEFAULT_PREDEFINED_SYMBOL">
+      <value>
+        <option name="FOREGROUND" value="4ecdc4" />
+      </value>
     </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
@@ -534,20 +514,20 @@
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="FOREGROUND" value="c8d7e8" />
+        <option name="BACKGROUND" value="2f3030" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +540,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +573,30 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
+      </value>
+    </option>
+    <option name="ENUM_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="80c0ba" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="bc3f3c" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="6a6f59" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +609,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +622,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +646,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +662,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,7 +675,7 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
@@ -732,22 +691,22 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="4ECDC4" />
+        <option name="FOREGROUND" value="4ecdc4" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +731,55 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="00A8C6" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="a8c6" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
+      </value>
+    </option>
+    <option name="INTERFACE_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="aedf34" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -831,18 +788,10 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="JAVA_COMMA">
-      <value>
-        <option name="FOREGROUND" value="C8D7E8" />
-      </value>
-    </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="737b84" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -851,56 +800,29 @@
     </option>
     <option name="JAVA_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="6a8759" />
-        <option name="EFFECT_COLOR" value="ff0000" />
+        <option name="FOREGROUND" value="ff260f" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
-      </value>
-    </option>
-    <option name="JAVA_LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-      </value>
-    </option>
-    <option name="JAVA_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="e9ee00" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
       </value>
     </option>
     <option name="JAVA_STRING">
       <value>
-        <option name="FOREGROUND" value="6a8759" />
-      </value>
-    </option>
-    <option name="JAVA_VALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="C8D7E8" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="e9ee00" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +841,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +877,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +914,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +928,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +941,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1083,39 +962,37 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="8FBE00" />
+        <option name="FOREGROUND" value="8fbe00" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="8FBE00" />
+        <option name="FOREGROUND" value="8fbe00" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
       </value>
     </option>
     <option name="OC.STRING">
@@ -1126,62 +1003,63 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
+      </value>
+    </option>
+    <option name="PARAMETER_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="fd971f" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="e9ee00" />
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
@@ -1191,64 +1069,75 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
       <value>
-        <option name="FOREGROUND" value="8888c6" />
+        <option name="FOREGROUND" value="a9ae92" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="aedf34" />
         <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="PY.DECORATOR">
+      <value>
+        <option name="FOREGROUND" value="e9ee00" />
+      </value>
+    </option>
+    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="a9ae92" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="a9ae92" />
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_USAGE">
+      <value>
+        <option name="FOREGROUND" value="a9ae92" />
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="a9ae92" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="PY.STRING.U">
+      <value>
+        <option name="FOREGROUND" value="a9ae92" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="c8d7e8" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1146,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="2f3030" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1167,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,13 +1186,13 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="8FBE00" />
+        <option name="FOREGROUND" value="8fbe00" />
       </value>
     </option>
     <option name="SQL_STRING">
@@ -1491,31 +1208,16 @@
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,13 +1230,13 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1543,15 +1245,9 @@
         <option name="FOREGROUND" value="e9ee00" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1258,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="BACKGROUND" value="2f3030" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,12 +1280,11 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="507874" />
+        <option name="FOREGROUND" value="dddddd" />
       </value>
     </option>
     <option name="TYPO">
@@ -1615,15 +1310,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1632,14 +1321,9 @@
         <option name="FOREGROUND" value="e9ee00" />
       </value>
     </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1334,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="C8D7E8" />
+        <option name="EFFECT_COLOR" value="c8d7e8" />
+        <option name="ERROR_STRIPE_COLOR" value="c8d7e8" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="C8D7E8" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2F3030" />
+        <option name="BACKGROUND" value="2f3030" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,7 +1363,7 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
@@ -1695,7 +1379,8 @@
     </option>
     <option name="XML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="6d9cbe" />
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,26 +1390,23 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="8FBE00" />
+        <option name="FOREGROUND" value="8fbe00" />
       </value>
     </option>
     <option name="XPATH.STRING">
@@ -1735,12 +1417,12 @@
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="00A8C6" />
+        <option name="FOREGROUND" value="a8c6" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="4ECDC4" />
+        <option name="FOREGROUND" value="4ecdc4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1772,7 +1454,7 @@
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="8FBE00" />
+        <option name="FOREGROUND" value="8fbe00" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1474,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="C8D7E8" />
+        <option name="FOREGROUND" value="c8d7e8" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/frontier.icls
+++ b/jetbrains/frontier.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Frontier" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Frontier" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="36312c" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="F23A3A" />
-    <option name="FILESTATUS_MODIFIED" value="F8BB39" />
+    <option name="FILESTATUS_MERGED" value="f23a3a" />
+    <option name="FILESTATUS_MODIFIED" value="f8bb39" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="F8BB39" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="F8BB39" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f8bb39" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="f8bb39" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="F8BB39" />
-    <option name="GUTTER_BACKGROUND" value="36312C" />
+    <option name="FILESTATUS_modifiedOutside" value="f8bb39" />
+    <option name="GUTTER_BACKGROUND" value="36312c" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,16 +59,9 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
+      <value />
     </option>
-    <option name="BASH.INTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="b0c95" />
-      </value>
-    </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BNF_EXTERNAL">
       <value>
         <option name="FONT_TYPE" value="2" />
@@ -88,12 +74,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +92,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +106,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +134,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +145,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +165,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +204,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +225,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +244,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +254,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +295,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +325,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +340,15 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,26 +360,23 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="2ebf7e" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -454,29 +393,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="6d689c" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,12 +433,12 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,51 +448,48 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="FOREGROUND" value="fc803d" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +502,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +535,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +566,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +579,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +603,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +619,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,38 +632,38 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="2ebf7e" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="2ebf7e" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="2EBF7E" />
+        <option name="FOREGROUND" value="2ebf7e" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +688,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="F23A3A" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="f23a3a" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +742,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +764,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +774,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +789,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +814,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +850,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +887,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +901,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +914,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +935,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="2EBF7E" />
+        <option name="FOREGROUND" value="2ebf7e" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="2EBF7E" />
+        <option name="FOREGROUND" value="2ebf7e" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="FOREGROUND" value="f8bb39" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1044,44 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
+    <option name="PY.DECORATOR" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="bc3f3c" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.KEYWORD_ARGUMENT">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="2ebf7e" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="fc803d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1090,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1111,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1130,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="2EBF7E" />
+        <option name="FOREGROUND" value="2ebf7e" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1174,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1202,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1224,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1254,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1278,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="FC803D" />
+        <option name="EFFECT_COLOR" value="fc803d" />
+        <option name="ERROR_STRIPE_COLOR" value="fc803d" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="FC803D" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1307,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,59 +1328,56 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="2EBF7E" />
+        <option name="FOREGROUND" value="2ebf7e" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="F23A3A" />
+        <option name="FOREGROUND" value="f23a3a" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="2EBF7E" />
+        <option name="FOREGROUND" value="2ebf7e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1387,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="2EBF7E" />
+        <option name="FOREGROUND" value="2ebf7e" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1412,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="FC803D" />
+        <option name="FOREGROUND" value="fc803d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/github.icls
+++ b/jetbrains/github.icls
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Github" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Github" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="CONSOLE_FONT_NAME" value="DejaVu Sans Mono" />
+  <option name="CONSOLE_FONT_SIZE" value="10" />
+  <option name="CONSOLE_LINE_SPACING" value="1.4" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
@@ -16,15 +18,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="008080" />
-    <option name="FILESTATUS_MODIFIED" value="DD1144" />
+    <option name="FILESTATUS_MERGED" value="8080" />
+    <option name="FILESTATUS_MODIFIED" value="dd1144" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="DD1144" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="DD1144" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="dd1144" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="dd1144" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="DD1144" />
+    <option name="FILESTATUS_modifiedOutside" value="dd1144" />
     <option name="GUTTER_BACKGROUND" value="ffffff" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,12 +55,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,15 +62,7 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="BASH.INTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="b0c95" />
-      </value>
+      <value />
     </option>
     <option name="BNF_EXTERNAL">
       <value>
@@ -88,12 +76,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +93,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +108,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="008080" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +136,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +147,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +167,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +229,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +246,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,12 +256,12 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
@@ -307,17 +272,17 @@
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -335,18 +300,6 @@
         <option name="FOREGROUND" value="555555" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
@@ -355,7 +308,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +327,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -400,9 +341,6 @@
       <value>
         <option name="FOREGROUND" value="4646f1" />
       </value>
-    </option>
-    <option name="Class">
-      <value />
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +356,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -461,7 +396,7 @@
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
@@ -476,7 +411,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -503,7 +438,7 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
@@ -514,22 +449,19 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
@@ -541,7 +473,7 @@
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +525,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +556,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +569,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +580,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +593,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,12 +622,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,7 +638,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -747,7 +653,7 @@
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +678,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="008080" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="8080" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +688,40 @@
         <option name="BACKGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -840,9 +739,6 @@
       <value>
         <option name="FOREGROUND" value="b8b6b1" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -868,7 +764,7 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
@@ -886,21 +782,10 @@
         <option name="FOREGROUND" value="555555" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +804,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="008080" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +852,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +877,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +891,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +904,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,7 +925,7 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
@@ -1094,7 +936,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1104,13 +945,12 @@
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1120,13 +960,12 @@
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1136,7 +975,7 @@
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1163,7 +1002,7 @@
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
         <option name="BACKGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1180,39 +1019,19 @@
         <option name="FOREGROUND" value="555555" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
       <value>
         <option name="FOREGROUND" value="8888c6" />
-      </value>
-    </option>
-    <option name="REGEXP.BRACES">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
@@ -1235,29 +1054,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="555555" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1080,16 @@
         <option name="BACKGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1475,47 +1111,32 @@
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,25 +1149,19 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1584,7 +1199,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1229,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="555555" />
@@ -1629,12 +1237,7 @@
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1655,15 +1258,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="555555" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="555555" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1282,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="b8b6b1" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1707,9 +1305,6 @@
       <value>
         <option name="FOREGROUND" value="555555" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1724,18 +1319,18 @@
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="008080" />
+        <option name="FOREGROUND" value="8080" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
@@ -1752,12 +1347,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1362,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="DD1144" />
+        <option name="FOREGROUND" value="dd1144" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,18 +1387,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="555555" />
@@ -1812,4 +1395,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/gloom.icls
+++ b/jetbrains/gloom.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Gloom" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Gloom" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="2a332b" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="FF5D38" />
-    <option name="FILESTATUS_MODIFIED" value="BCD42A" />
+    <option name="FILESTATUS_MERGED" value="ff5d38" />
+    <option name="FILESTATUS_MODIFIED" value="bcd42a" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="BCD42A" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="BCD42A" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="bcd42a" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="bcd42a" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="BCD42A" />
-    <option name="GUTTER_BACKGROUND" value="2A332B" />
+    <option name="FILESTATUS_modifiedOutside" value="bcd42a" />
+    <option name="GUTTER_BACKGROUND" value="2a332b" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +216,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +307,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +352,14 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="947494" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F6E64" />
+        <option name="FOREGROUND" value="4f6e64" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,26 +371,23 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F6E64" />
+        <option name="FOREGROUND" value="4f6e64" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -454,29 +404,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="947494" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="D8EBE5" />
+        <option name="FOREGROUND" value="d8ebe5" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="D8EBE5" />
+        <option name="FOREGROUND" value="d8ebe5" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,12 +444,12 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F6E64" />
+        <option name="FOREGROUND" value="4f6e64" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,51 +459,48 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="FOREGROUND" value="26a6a6" />
+        <option name="BACKGROUND" value="2a332b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +513,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +546,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +577,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +590,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +614,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +630,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="D8EBE5" />
+        <option name="FOREGROUND" value="d8ebe5" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,38 +643,38 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F6E64" />
+        <option name="FOREGROUND" value="4f6e64" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="D8EBE5" />
+        <option name="FOREGROUND" value="d8ebe5" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +699,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="FF5D38" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="ff5d38" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +753,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F6E64" />
+        <option name="FOREGROUND" value="4f6e64" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +775,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +785,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +800,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +825,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +861,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +898,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +912,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +925,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +946,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="D8EBE5" />
+        <option name="FOREGROUND" value="d8ebe5" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="D8EBE5" />
+        <option name="FOREGROUND" value="d8ebe5" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="FOREGROUND" value="bcd42a" />
+        <option name="BACKGROUND" value="2a332b" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="D8EBE5" />
+        <option name="FOREGROUND" value="d8ebe5" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1055,35 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
+    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
+    <option name="PY.DECORATOR" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1092,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1113,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1132,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1176,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1204,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="D8EBE5" />
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="FOREGROUND" value="d8ebe5" />
+        <option name="BACKGROUND" value="2a332b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1226,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1256,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1280,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="26A6A6" />
+        <option name="EFFECT_COLOR" value="26a6a6" />
+        <option name="ERROR_STRIPE_COLOR" value="26a6a6" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="26A6A6" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2A332B" />
+        <option name="BACKGROUND" value="2a332b" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1309,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F6E64" />
+        <option name="FOREGROUND" value="4f6e64" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,59 +1330,56 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="D8EBE5" />
+        <option name="FOREGROUND" value="d8ebe5" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F6E64" />
+        <option name="FOREGROUND" value="4f6e64" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1389,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1414,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/glowfish.icls
+++ b/jetbrains/glowfish.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Glowfish" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Glowfish" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="191f13" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,15 +15,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="DB784D" />
-    <option name="FILESTATUS_MODIFIED" value="F8BB39" />
+    <option name="FILESTATUS_MERGED" value="db784d" />
+    <option name="FILESTATUS_MODIFIED" value="f8bb39" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="F8BB39" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="F8BB39" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f8bb39" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="f8bb39" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="F8BB39" />
+    <option name="FILESTATUS_modifiedOutside" value="f8bb39" />
     <option name="GUTTER_BACKGROUND" value="191f13" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +103,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +307,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="D65940" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +318,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="947494" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,14 +405,20 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="947494" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
@@ -476,7 +433,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,45 +460,42 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
         <option name="BACKGROUND" value="191f13" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +547,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +578,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +591,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +615,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,12 +644,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,7 +660,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -742,12 +670,12 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="95CC5E" />
+        <option name="FOREGROUND" value="95cc5e" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +700,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="DB784D" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="db784d" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +710,40 @@
         <option name="BACKGROUND" value="191f13" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +754,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="3c4e2d" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +776,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +786,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +801,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="D65940" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +826,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +862,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +899,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +913,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +926,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,60 +947,57 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="95CC5E" />
+        <option name="FOREGROUND" value="95cc5e" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="95CC5E" />
+        <option name="FOREGROUND" value="95cc5e" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,7 +1009,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1163,7 +1024,7 @@
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
         <option name="BACKGROUND" value="191f13" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1171,7 +1032,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1180,18 +1041,14 @@
         <option name="FOREGROUND" value="6ea240" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1056,15 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
+    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
+    <option name="PY.DECORATOR" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1078,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="D65940" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="d65940" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1108,16 @@
         <option name="BACKGROUND" value="191f13" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,53 +1133,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="95CC5E" />
+        <option name="FOREGROUND" value="95cc5e" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1177,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1227,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1257,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1281,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="D65940" />
+        <option name="EFFECT_COLOR" value="d65940" />
+        <option name="ERROR_STRIPE_COLOR" value="d65940" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="D65940" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1310,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="3c4e2d" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1708,39 +1334,36 @@
         <option name="FOREGROUND" value="6ea240" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="95CC5E" />
+        <option name="FOREGROUND" value="95cc5e" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="DB784D" />
+        <option name="FOREGROUND" value="db784d" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="95CC5E" />
+        <option name="FOREGROUND" value="95cc5e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1375,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1390,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="95CC5E" />
+        <option name="FOREGROUND" value="95cc5e" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1415,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="D65940" />
+        <option name="FOREGROUND" value="d65940" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/grunge.icls
+++ b/jetbrains/grunge.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Grunge" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Grunge" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="31332c" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="F56991" />
-    <option name="FILESTATUS_MODIFIED" value="D1F2A5" />
+    <option name="FILESTATUS_MERGED" value="f56991" />
+    <option name="FILESTATUS_MODIFIED" value="d1f2a5" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="D1F2A5" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="D1F2A5" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="d1f2a5" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="d1f2a5" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="D1F2A5" />
-    <option name="GUTTER_BACKGROUND" value="31332C" />
+    <option name="FILESTATUS_modifiedOutside" value="d1f2a5" />
+    <option name="GUTTER_BACKGROUND" value="31332c" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F56991" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +216,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +307,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="91A374" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +352,9 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
-    </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="5C634F" />
+        <option name="FOREGROUND" value="5c634f" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,26 +366,23 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="5C634F" />
+        <option name="FOREGROUND" value="5c634f" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -456,27 +401,27 @@
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,12 +433,12 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="5C634F" />
+        <option name="FOREGROUND" value="5c634f" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,51 +448,48 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="91A374" />
-        <option name="BACKGROUND" value="31332C" />
+        <option name="FOREGROUND" value="91a374" />
+        <option name="BACKGROUND" value="31332c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +502,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +535,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +566,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +579,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +603,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +619,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,38 +632,38 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="5C634F" />
+        <option name="FOREGROUND" value="5c634f" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +688,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="F56991" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="f56991" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +742,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="5C634F" />
+        <option name="FOREGROUND" value="5c634f" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +764,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +774,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +789,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="91A374" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +814,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="F56991" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +850,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +887,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +901,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +914,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +935,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
-        <option name="BACKGROUND" value="31332C" />
+        <option name="FOREGROUND" value="d1f2a5" />
+        <option name="BACKGROUND" value="31332c" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1044,49 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="d1f2a5" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="91A374" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="91a374" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1095,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="31332C" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1116,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1135,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1179,30 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
+    <option name="TAG">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="947494" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1213,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
-        <option name="BACKGROUND" value="31332C" />
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="BACKGROUND" value="31332c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1235,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1265,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1289,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="91A374" />
+        <option name="EFFECT_COLOR" value="91a374" />
+        <option name="ERROR_STRIPE_COLOR" value="91a374" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="91A374" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="31332C" />
+        <option name="BACKGROUND" value="31332c" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1318,24 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="5C634F" />
+        <option name="FOREGROUND" value="5c634f" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="XML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="6d9cbe" />
+        <option name="FOREGROUND" value="947494" />
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,59 +1345,56 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="5C634F" />
+        <option name="FOREGROUND" value="5c634f" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1404,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="D1F2A5" />
+        <option name="FOREGROUND" value="d1f2a5" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="F56991" />
+        <option name="FOREGROUND" value="f56991" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1429,17 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
+    <option name="Yaml Specials">
       <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="947494" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="91A374" />
+        <option name="FOREGROUND" value="91a374" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/halflife.icls
+++ b/jetbrains/halflife.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Halflife" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Halflife" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="222222" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,15 +15,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="7D8991" />
-    <option name="FILESTATUS_MODIFIED" value="F9D423" />
+    <option name="FILESTATUS_MERGED" value="7d8991" />
+    <option name="FILESTATUS_MODIFIED" value="f9d423" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="F9D423" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="F9D423" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f9d423" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="f9d423" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="F9D423" />
+    <option name="FILESTATUS_modifiedOutside" value="f9d423" />
     <option name="GUTTER_BACKGROUND" value="222222" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -36,7 +35,7 @@
     <option name="RIGHT_MARGIN_COLOR" value="323232" />
     <option name="SELECTED_INDENT_GUIDE" value="505050" />
     <option name="SELECTED_TEARLINE_COLOR" value="787878" />
-    <option name="SELECTION_BACKGROUND" value="161a1f" />
+    <option name="SELECTION_BACKGROUND" value="292d30" />
     <option name="SELECTION_FOREGROUND" value="" />
     <option name="TEARLINE_COLOR" value="303134" />
     <option name="WHITESPACES" value="505050" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,21 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="90c93f" />
+      </value>
+    </option>
+    <option name="BASH.REDIRECTION">
+      <value>
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +88,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +106,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="222222" />
+        <option name="BACKGROUND" value="3d5054" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +120,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +148,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +159,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +179,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +241,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +258,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +268,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +309,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +320,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +339,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -400,9 +353,6 @@
       <value>
         <option name="FOREGROUND" value="4646f1" />
       </value>
-    </option>
-    <option name="Class">
-      <value />
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +368,23 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_COMMA">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="c0d5c1" />
+      </value>
     </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -456,17 +408,17 @@
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="cccccc" />
+        <option name="FOREGROUND" value="c0d5c1" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
@@ -476,7 +428,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +440,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,45 +455,42 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,20 +542,19 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="222222" />
+        <option name="BACKGROUND" value="3d5054" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
@@ -625,8 +573,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +586,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +610,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,12 +639,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,7 +655,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -742,12 +665,12 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FC913A" />
+        <option name="FOREGROUND" value="fc913a" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +695,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="7D8991" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="7d8991" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +705,40 @@
         <option name="BACKGROUND" value="222222" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +749,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="555555" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +771,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +781,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +796,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +821,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +857,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +894,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +908,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +921,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,60 +942,57 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,7 +1004,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1163,7 +1019,7 @@
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
         <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1171,7 +1027,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1180,18 +1036,14 @@
         <option name="FOREGROUND" value="cccccc" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1051,49 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="59747a" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f9d423" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="90c93f" />
+      </value>
+    </option>
+    <option name="PY.PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="c0d5c1" />
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="c0d5c1" />
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="81a0a4" />
+      </value>
+    </option>
+    <option name="PY.STRING.U">
+      <value>
+        <option name="FOREGROUND" value="749aa0" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1107,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1137,16 @@
         <option name="BACKGROUND" value="222222" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,53 +1162,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1206,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1256,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1286,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1310,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="7D8991" />
+        <option name="EFFECT_COLOR" value="7d8991" />
+        <option name="ERROR_STRIPE_COLOR" value="7d8991" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="7D8991" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1339,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="59747a" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="555555" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1708,39 +1363,31 @@
         <option name="FOREGROUND" value="cccccc" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
-    <option name="XML_TAG_NAME">
-      <value>
-        <option name="FOREGROUND" value="7D8991" />
-      </value>
-    </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="FC913A" />
+        <option name="FOREGROUND" value="fc913a" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1399,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1414,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="F9D423" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1439,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="7D8991" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/heroku.icls
+++ b/jetbrains/heroku.icls
@@ -1,14 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Heroku" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Heroku" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="CONSOLE_FONT_NAME" value="DejaVu Sans Mono" />
+  <option name="CONSOLE_FONT_SIZE" value="10" />
+  <option name="CONSOLE_LINE_SPACING" value="1.4" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="1b1b24" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -53,12 +55,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +62,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="a6fa62" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="7873ae" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -106,9 +107,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="1b1b24" />
@@ -123,14 +121,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="7873ae" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +149,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +160,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +180,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -256,12 +240,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -335,18 +313,6 @@
         <option name="FOREGROUND" value="7873ae" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
@@ -374,18 +340,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="a6fa62" />
@@ -401,8 +355,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="947494" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -427,9 +384,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
         <option name="FOREGROUND" value="7873ae" />
@@ -453,6 +407,12 @@
     </option>
     <option name="DEFAULT_DOT">
       <value />
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="947494" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
@@ -512,9 +472,6 @@
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
-      <value />
-    </option>
-    <option name="DEFAULT_SEMICOLON">
       <value />
     </option>
     <option name="DEFAULT_STATIC_FIELD">
@@ -593,15 +550,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +594,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +605,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +618,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -773,17 +704,14 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="7873ae" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
         <option name="BACKGROUND" value="1b1b24" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +722,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -840,9 +764,6 @@
       <value>
         <option name="FOREGROUND" value="505067" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -886,21 +807,10 @@
         <option name="FOREGROUND" value="7873ae" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="7873ae" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +877,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +929,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1094,7 +961,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1110,7 +976,6 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1126,7 +991,6 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1180,9 +1044,6 @@
         <option name="FOREGROUND" value="c8c7d5" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
         <option name="FOREGROUND" value="a6fa62" />
@@ -1191,7 +1052,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,21 +1059,23 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="7873ae" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="c8c7d5" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="a6fa62" />
       </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
@@ -1235,29 +1097,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="7873ae" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1123,16 @@
         <option name="BACKGROUND" value="1b1b24" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1503,21 +1182,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
     <option name="Static field">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1541,12 +1205,6 @@
     <option name="String">
       <value>
         <option name="FOREGROUND" value="a6fa62" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1584,7 +1242,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1272,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="7873ae" />
@@ -1630,11 +1281,6 @@
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="a6fa62" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1655,15 +1301,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="7873ae" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="7873ae" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1693,11 +1339,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1707,9 +1348,6 @@
       <value>
         <option name="FOREGROUND" value="c8c7d5" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1792,18 +1430,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="7873ae" />
@@ -1812,4 +1438,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/hyrule.icls
+++ b/jetbrains/hyrule.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Hyrule" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Hyrule" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="2d2c2b" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -36,8 +35,8 @@
     <option name="RIGHT_MARGIN_COLOR" value="323232" />
     <option name="SELECTED_INDENT_GUIDE" value="505050" />
     <option name="SELECTED_TEARLINE_COLOR" value="787878" />
-    <option name="SELECTION_BACKGROUND" value="161a1f" />
-    <option name="SELECTION_FOREGROUND" value="" />
+    <option name="SELECTION_BACKGROUND" value="59747a" />
+    <option name="SELECTION_FOREGROUND" value="161a1f" />
     <option name="TEARLINE_COLOR" value="303134" />
     <option name="WHITESPACES" value="505050" />
   </colors>
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,21 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="ce830d" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="b5a5d5" />
+      </value>
+    </option>
+    <option name="BASH.REDIRECTION">
+      <value>
+        <option name="FOREGROUND" value="90c93f" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -106,12 +106,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2d2c2b" />
+        <option name="BACKGROUND" value="3d5054" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +120,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="569e16" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +148,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +159,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +179,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -256,12 +239,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -335,18 +312,6 @@
         <option name="FOREGROUND" value="90c93f" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
@@ -374,18 +339,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ce830d" />
@@ -401,8 +354,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="947494" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -427,9 +383,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
         <option name="FOREGROUND" value="569e16" />
@@ -453,6 +406,12 @@
     </option>
     <option name="DEFAULT_DOT">
       <value />
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="947494" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
@@ -512,9 +471,6 @@
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
-      <value />
-    </option>
-    <option name="DEFAULT_SEMICOLON">
       <value />
     </option>
     <option name="DEFAULT_STATIC_FIELD">
@@ -593,20 +549,19 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2d2c2b" />
+        <option name="BACKGROUND" value="3d5054" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
@@ -625,8 +580,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +593,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +604,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +617,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -773,17 +703,14 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="569e16" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
         <option name="BACKGROUND" value="2d2c2b" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +721,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -840,9 +763,6 @@
       <value>
         <option name="FOREGROUND" value="716d6a" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -886,21 +806,10 @@
         <option name="FOREGROUND" value="90c93f" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +828,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="569e16" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +876,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +901,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +915,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +928,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1094,7 +960,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1110,7 +975,6 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1126,7 +990,6 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1180,9 +1043,6 @@
         <option name="FOREGROUND" value="c0d5c1" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
         <option name="FOREGROUND" value="ce830d" />
@@ -1191,28 +1051,49 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
       <value>
-        <option name="FOREGROUND" value="8888c6" />
+        <option name="FOREGROUND" value="569e16" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="569e16" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="90c62d" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="716d6a" />
+      </value>
+    </option>
+    <option name="PY.FUNC_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="ce830d" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
+    </option>
+    <option name="PY.PREDEFINED_USAGE">
+      <value>
+        <option name="FOREGROUND" value="569e16" />
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="90c62d" />
+      </value>
+    </option>
+    <option name="PY.STRING.U">
+      <value>
+        <option name="FOREGROUND" value="b5a5d5" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
@@ -1235,29 +1116,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="90c93f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1142,16 @@
         <option name="BACKGROUND" value="2d2c2b" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1503,21 +1201,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
     <option name="Static field">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1541,12 +1224,6 @@
     <option name="String">
       <value>
         <option name="FOREGROUND" value="ce830d" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1584,7 +1261,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1291,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="90c93f" />
@@ -1630,11 +1300,6 @@
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="ce830d" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1655,15 +1320,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="90c93f" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="90c93f" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1693,11 +1358,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1707,9 +1367,6 @@
       <value>
         <option name="FOREGROUND" value="c0d5c1" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1792,18 +1449,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="90c93f" />
@@ -1812,4 +1457,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/iceberg.icls
+++ b/jetbrains/iceberg.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Iceberg" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Iceberg" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="323b3d" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="2D8DA1" />
-    <option name="FILESTATUS_MODIFIED" value="FFFFFF" />
+    <option name="FILESTATUS_MERGED" value="2d8da1" />
+    <option name="FILESTATUS_MODIFIED" value="ffffff" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="FFFFFF" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="FFFFFF" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="ffffff" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="ffffff" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="FFFFFF" />
-    <option name="GUTTER_BACKGROUND" value="323B3D" />
+    <option name="FILESTATUS_modifiedOutside" value="ffffff" />
+    <option name="GUTTER_BACKGROUND" value="323b3d" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +216,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +307,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,29 +405,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="BDD6DB" />
+        <option name="FOREGROUND" value="bdd6db" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="BDD6DB" />
+        <option name="FOREGROUND" value="bdd6db" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,51 +460,48 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="FOREGROUND" value="b1e2f2" />
+        <option name="BACKGROUND" value="323b3d" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +514,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +547,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +578,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +591,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +615,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +631,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="BDD6DB" />
+        <option name="FOREGROUND" value="bdd6db" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,12 +644,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,22 +660,22 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="BDD6DB" />
+        <option name="FOREGROUND" value="bdd6db" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="59C0E3" />
+        <option name="FOREGROUND" value="59c0e3" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +700,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="2D8DA1" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="2d8da1" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +754,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="537178" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +776,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +786,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +801,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +826,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -976,21 +860,27 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="JSON.INVALID_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f23a3a" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +906,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +920,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +933,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +954,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="BDD6DB" />
+        <option name="FOREGROUND" value="bdd6db" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="BDD6DB" />
+        <option name="FOREGROUND" value="bdd6db" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="323b3d" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="BDD6DB" />
+        <option name="FOREGROUND" value="bdd6db" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1063,54 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="bdd6db" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f23a3a" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="b1e2f2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1119,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1140,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1159,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1203,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1231,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="BDD6DB" />
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="FOREGROUND" value="bdd6db" />
+        <option name="BACKGROUND" value="323b3d" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1253,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1283,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1307,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="B1E2F2" />
+        <option name="EFFECT_COLOR" value="b1e2f2" />
+        <option name="ERROR_STRIPE_COLOR" value="b1e2f2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="B1E2F2" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="323B3D" />
+        <option name="BACKGROUND" value="323b3d" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1336,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="537178" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,42 +1357,39 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="BDD6DB" />
+        <option name="FOREGROUND" value="bdd6db" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="2D8DA1" />
+        <option name="FOREGROUND" value="2d8da1" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="59C0E3" />
+        <option name="FOREGROUND" value="59c0e3" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1401,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1416,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1441,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="B1E2F2" />
+        <option name="FOREGROUND" value="b1e2f2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/ironleaf.icls
+++ b/jetbrains/ironleaf.icls
@@ -1,4 +1,4 @@
-<scheme name="Goldfish" version="142" parent_scheme="Default">
+<scheme name="IronLeaf" version="142" parent_scheme="Default">
   <option name="LINE_SPACING" value="1.0" />
   <option name="EDITOR_FONT_SIZE" value="14" />
   <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
@@ -7,7 +7,7 @@
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2e3336" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="222222" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -15,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="fa6900" />
-    <option name="FILESTATUS_MODIFIED" value="f36e3a" />
+    <option name="FILESTATUS_MERGED" value="7d8991" />
+    <option name="FILESTATUS_MODIFIED" value="f9d423" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f36e3a" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="f36e3a" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f9d423" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="f9d423" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="f36e3a" />
-    <option name="GUTTER_BACKGROUND" value="2e3336" />
+    <option name="FILESTATUS_modifiedOutside" value="f9d423" />
+    <option name="GUTTER_BACKGROUND" value="222222" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -35,7 +35,7 @@
     <option name="RIGHT_MARGIN_COLOR" value="323232" />
     <option name="SELECTED_INDENT_GUIDE" value="505050" />
     <option name="SELECTED_TEARLINE_COLOR" value="787878" />
-    <option name="SELECTION_BACKGROUND" value="161a1f" />
+    <option name="SELECTION_BACKGROUND" value="292d30" />
     <option name="SELECTION_FOREGROUND" value="" />
     <option name="TEARLINE_COLOR" value="303134" />
     <option name="WHITESPACES" value="505050" />
@@ -63,15 +63,12 @@
     </option>
     <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="90c62d" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
-      <value />
-    </option>
-    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="90c93f" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -86,12 +83,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,7 +103,7 @@
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="3d5054" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -124,7 +121,7 @@
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -216,12 +213,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -237,6 +234,11 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
+      </value>
+    </option>
+    <option name="CONSOLE_USER_INPUT">
+      <value>
+        <option name="FOREGROUND" value="7f00" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -256,7 +258,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -266,33 +268,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -307,18 +309,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -339,7 +341,7 @@
     </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -354,13 +356,13 @@
     </option>
     <option name="DEFAULT_ATTRIBUTE">
       <value>
-        <option name="FOREGROUND" value="947494" />
+        <option name="FOREGROUND" value="a495ff" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="505c63" />
+        <option name="FOREGROUND" value="555555" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -372,34 +374,39 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_COMMA">
+      <value>
+        <option name="FOREGROUND" value="c0d5c1" />
       </value>
     </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="505c63" />
+        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
       <value>
-        <option name="FOREGROUND" value="798891" />
+        <option name="FOREGROUND" value="808080" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEFAULT_DOC_MARKUP">
       <value>
-        <option name="FOREGROUND" value="798891" />
+        <option name="FOREGROUND" value="808080" />
       </value>
     </option>
     <option name="DEFAULT_DOT">
@@ -407,33 +414,33 @@
     </option>
     <option name="DEFAULT_ENTITY">
       <value>
-        <option name="FOREGROUND" value="947494" />
+        <option name="FOREGROUND" value="a495ff" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="90c62d" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="FOREGROUND" value="c0d5c1" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="FOREGROUND" value="cccccc" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -445,27 +452,27 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="505c63" />
+        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
       <value>
-        <option name="FOREGROUND" value="bbb529" />
+        <option name="FOREGROUND" value="6e9722" />
       </value>
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="90c62d" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
@@ -473,35 +480,35 @@
     </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="90c62d" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="FOREGROUND" value="7d8991" />
+        <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -514,31 +521,31 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
     <option name="DOC_COMMENT_TAG_VALUE">
       <value>
-        <option name="FOREGROUND" value="798891" />
+        <option name="FOREGROUND" value="808080" />
       </value>
     </option>
     <option name="DUPLICATE_FROM_SERVER">
@@ -559,13 +566,13 @@
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="48661a" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -595,7 +602,7 @@
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="GString">
@@ -623,7 +630,7 @@
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -631,7 +638,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="FOREGROUND" value="cccccc" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -644,38 +651,38 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="505c63" />
+        <option name="FOREGROUND" value="555555" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="FOREGROUND" value="cccccc" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="f38630" />
+        <option name="FOREGROUND" value="fc913a" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -700,19 +707,19 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="fa6900" />
+        <option name="EFFECT_COLOR" value="7d8991" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
       </value>
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -738,12 +745,12 @@
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -754,12 +761,12 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="505c63" />
+        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="JAVA_DOC_TAG">
@@ -776,7 +783,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -786,12 +793,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -801,7 +808,7 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
@@ -834,7 +841,7 @@
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
@@ -860,15 +867,22 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="JSON.INVALID_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f23a3a" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="LABEL">
@@ -930,7 +944,7 @@
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="Map key">
@@ -947,12 +961,12 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="f25619" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
@@ -962,12 +976,12 @@
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="f25619" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="OC.PROPERTY">
@@ -977,12 +991,12 @@
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
@@ -992,58 +1006,58 @@
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="FOREGROUND" value="cccccc" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="FOREGROUND" value="cccccc" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="FOREGROUND" value="f9d423" />
+        <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="FOREGROUND" value="cccccc" />
       </value>
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
@@ -1053,38 +1067,79 @@
     </option>
     <option name="PY.BUILTIN_NAME">
       <value>
-        <option name="FOREGROUND" value="8888c6" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
-    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
-    <option name="PY.DECORATOR" baseAttributes="DEFAULT_IDENTIFIER" />
-    <option name="PY.FUNC_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="PY.CLASS_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="7d8991" />
+      </value>
+    </option>
+    <option name="PY.DECORATOR">
+      <value>
+        <option name="FOREGROUND" value="59747a" />
+      </value>
+    </option>
+    <option name="PY.FUNC_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="90c62d" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f23a3a" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="PY.KEYWORD_ARGUMENT">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="f9d423" />
+      </value>
+    </option>
+    <option name="PY.PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="c0d5c1" />
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="c0d5c1" />
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="edb92e" />
+      </value>
+    </option>
+    <option name="PY.STRING.U">
+      <value>
+        <option name="FOREGROUND" value="749aa0" />
+      </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1095,17 +1150,17 @@
     </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1121,7 +1176,7 @@
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1133,36 +1188,36 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="f25619" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -1177,24 +1232,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1205,14 +1260,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="f8f8f2" />
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="FOREGROUND" value="cccccc" />
+        <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1259,18 +1314,18 @@
     </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1281,7 +1336,7 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
@@ -1292,14 +1347,14 @@
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="a7dbd8" />
-        <option name="ERROR_STRIPE_COLOR" value="a7dbd8" />
+        <option name="EFFECT_COLOR" value="7d8991" />
+        <option name="ERROR_STRIPE_COLOR" value="7d8991" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2e3336" />
+        <option name="BACKGROUND" value="222222" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1310,17 +1365,17 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="59747a" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="505c63" />
+        <option name="FOREGROUND" value="555555" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1331,56 +1386,51 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="f8f8f2" />
-      </value>
-    </option>
-    <option name="XML_TAG_NAME">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="cccccc" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="f25619" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="fa6900" />
+        <option name="FOREGROUND" value="7d8991" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="f38630" />
+        <option name="FOREGROUND" value="fc913a" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="505c63" />
+        <option name="FOREGROUND" value="555555" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1390,12 +1440,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="f25619" />
+        <option name="FOREGROUND" value="f9d423" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1417,7 +1467,7 @@
     </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FOREGROUND" value="7d8991" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>

--- a/jetbrains/juicy.icls
+++ b/jetbrains/juicy.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Juicy" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Juicy" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="222222" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -32,11 +31,11 @@
     <option name="MODIFIED_LINES_COLOR" value="" />
     <option name="NOTIFICATION_BACKGROUND" value="3d1a11" />
     <option name="READONLY_FRAGMENT_BACKGROUND" value="" />
-    <option name="RECURSIVE_CALL_ATTRIBUTES" value="574300" />
+    <option name="RECURSIVE_CALL_ATTRIBUTES" value="ffffff" />
     <option name="RIGHT_MARGIN_COLOR" value="323232" />
     <option name="SELECTED_INDENT_GUIDE" value="505050" />
     <option name="SELECTED_TEARLINE_COLOR" value="787878" />
-    <option name="SELECTION_BACKGROUND" value="161a1f" />
+    <option name="SELECTION_BACKGROUND" value="26776a" />
     <option name="SELECTION_FOREGROUND" value="" />
     <option name="TEARLINE_COLOR" value="303134" />
     <option name="WHITESPACES" value="505050" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="3bc7b8" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="222222" />
+        <option name="BACKGROUND" value="194d43" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="3bc7b8" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -301,7 +276,7 @@
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -332,19 +307,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -374,18 +337,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="3bc7b8" />
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -428,7 +382,9 @@
       </value>
     </option>
     <option name="DEFAULT_COMMA">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="c0d5c1" />
+      </value>
     </option>
     <option name="DEFAULT_CONSTANT">
       <value>
@@ -454,9 +410,15 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
@@ -488,7 +450,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -508,13 +470,10 @@
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
-      <value />
-    </option>
-    <option name="DEFAULT_SEMICOLON">
       <value />
     </option>
     <option name="DEFAULT_STATIC_FIELD">
@@ -532,9 +491,12 @@
         <option name="FOREGROUND" value="3bc7b8" />
       </value>
     </option>
+    <option name="DEFAULT_TAG">
+      <value />
+    </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
         <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
@@ -593,20 +555,19 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="222222" />
+        <option name="BACKGROUND" value="3d5054" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
@@ -625,8 +586,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +599,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +623,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -721,7 +657,7 @@
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="3bc7b8" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,7 +668,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="3bc7b8" />
+        <option name="FOREGROUND" value="c0d5c1" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -742,7 +678,7 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
@@ -773,17 +709,14 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="3bc7b8" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
         <option name="BACKGROUND" value="222222" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +727,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -833,16 +762,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="777777" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +784,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -873,7 +799,7 @@
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +809,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +834,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="3bc7b8" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -976,21 +868,27 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="JSON.INVALID_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f23a3a" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +914,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +928,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +941,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1083,39 +962,37 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="CE1836" />
+        <option name="FOREGROUND" value="ce1836" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="CE1836" />
+        <option name="FOREGROUND" value="ce1836" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="OC.STRING">
@@ -1126,12 +1003,11 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
@@ -1148,7 +1024,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1171,7 +1047,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1179,9 +1055,6 @@
       <value>
         <option name="FOREGROUND" value="e3e2e0" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
@@ -1191,7 +1064,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1071,61 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="3bc7b8" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="3bc7b8" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f23a3a" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="edb92e" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+      </value>
+    </option>
+    <option name="PY.PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="c0d5c1" />
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="3bc7b8" />
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="a291d5" />
+      </value>
+    </option>
+    <option name="PY.VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="c0d5c1" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1139,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="edb92e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1169,16 @@
         <option name="BACKGROUND" value="222222" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,13 +1194,13 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="CE1836" />
+        <option name="FOREGROUND" value="ce1836" />
       </value>
     </option>
     <option name="SQL_STRING">
@@ -1503,21 +1228,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
     <option name="Static field">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1543,15 +1253,9 @@
         <option name="FOREGROUND" value="3bc7b8" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1288,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1318,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="3bc7b8" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1342,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="EDB92E" />
+        <option name="EFFECT_COLOR" value="edb92e" />
+        <option name="ERROR_STRIPE_COLOR" value="edb92e" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="EDB92E" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1693,11 +1385,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1708,23 +1395,20 @@
         <option name="FOREGROUND" value="e3e2e0" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="CE1836" />
+        <option name="FOREGROUND" value="ce1836" />
       </value>
     </option>
     <option name="XPATH.STRING">
@@ -1740,7 +1424,7 @@
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1772,7 +1456,7 @@
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="CE1836" />
+        <option name="FOREGROUND" value="ce1836" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1476,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="EDB92E" />
+        <option name="FOREGROUND" value="edb92e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/keen.icls
+++ b/jetbrains/keen.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Keen" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Keen" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="111111" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="b5db99" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -106,9 +104,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="111111" />
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="8767b7" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -301,7 +276,7 @@
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -332,19 +307,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -374,18 +337,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="b5db99" />
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -426,9 +380,6 @@
         <option name="FOREGROUND" value="8767b7" />
         <option name="FONT_TYPE" value="2" />
       </value>
-    </option>
-    <option name="DEFAULT_COMMA">
-      <value />
     </option>
     <option name="DEFAULT_CONSTANT">
       <value>
@@ -454,9 +405,15 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -508,13 +465,10 @@
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
-      <value />
-    </option>
-    <option name="DEFAULT_SEMICOLON">
       <value />
     </option>
     <option name="DEFAULT_STATIC_FIELD">
@@ -532,9 +486,12 @@
         <option name="FOREGROUND" value="b5db99" />
       </value>
     </option>
+    <option name="DEFAULT_TAG">
+      <value />
+    </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="BACKGROUND" value="111111" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
@@ -593,15 +550,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +618,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -742,7 +673,7 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
@@ -773,17 +704,14 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="8767b7" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
         <option name="BACKGROUND" value="111111" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +722,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="374c60" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -873,7 +794,7 @@
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="8767b7" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -976,21 +863,27 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="JSON.INVALID_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f23a3a" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +909,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +923,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +936,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1088,18 +962,17 @@
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="OC.NUMBER">
@@ -1110,12 +983,11 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="OC.STRING">
@@ -1126,12 +998,11 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
@@ -1148,7 +1019,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1171,7 +1042,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1179,9 +1050,6 @@
       <value>
         <option name="FOREGROUND" value="cccccc" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
@@ -1191,7 +1059,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1066,36 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="8767b7" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="cccccc" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="b5db99" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f23a3a" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="7b9397" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1109,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1139,16 @@
         <option name="BACKGROUND" value="111111" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,7 +1164,7 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1503,21 +1198,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
     <option name="Static field">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1543,15 +1223,9 @@
         <option name="FOREGROUND" value="b5db99" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1258,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1288,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="b5db99" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1312,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="6F8B94" />
+        <option name="EFFECT_COLOR" value="6f8b94" />
+        <option name="ERROR_STRIPE_COLOR" value="6f8b94" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="6F8B94" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1693,11 +1355,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1708,17 +1365,14 @@
         <option name="FOREGROUND" value="cccccc" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1740,7 +1394,7 @@
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1792,24 +1446,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="6F8B94" />
+        <option name="FOREGROUND" value="6f8b94" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/kiwi.icls
+++ b/jetbrains/kiwi.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Kiwi" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Kiwi" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="161a19" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,7 +15,7 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="95C72A" />
+    <option name="FILESTATUS_MERGED" value="95c72a" />
     <option name="FILESTATUS_MODIFIED" value="a1e6c1" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
     <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="a1e6c1" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,21 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="a1e6c1" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="95c72a" />
+      </value>
+    </option>
+    <option name="BASH.REDIRECTION">
+      <value>
+        <option name="FOREGROUND" value="229986" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,7 +88,7 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="BNF_NUMBER">
@@ -106,9 +106,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="161a19" />
@@ -123,14 +120,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +148,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +159,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +179,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +241,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -296,7 +273,7 @@
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
@@ -307,7 +284,7 @@
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="CSS.NUMBER">
@@ -317,7 +294,7 @@
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -335,18 +312,6 @@
         <option name="FOREGROUND" value="229986" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
@@ -355,7 +320,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,18 +339,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="a1e6c1" />
@@ -401,12 +354,15 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="354341" />
+        <option name="FOREGROUND" value="556b68" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,32 +374,35 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="354341" />
+        <option name="FOREGROUND" value="556b68" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
       <value>
         <option name="FOREGROUND" value="5b7a75" />
         <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
+      <value>
+        <option name="FOREGROUND" value="7b9397" />
+        <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="DEFAULT_DOC_MARKUP">
@@ -453,6 +412,12 @@
     </option>
     <option name="DEFAULT_DOT">
       <value />
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
@@ -466,17 +431,17 @@
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -493,7 +458,7 @@
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="354341" />
+        <option name="FOREGROUND" value="556b68" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -514,23 +479,23 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
         <option name="FOREGROUND" value="a1e6c1" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
@@ -541,7 +506,7 @@
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +558,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="f23a3a" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +589,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +602,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +613,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +626,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -703,7 +642,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,7 +655,7 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
@@ -732,12 +671,12 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
@@ -747,7 +686,7 @@
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +711,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="95C72A" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="95c72a" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +721,40 @@
         <option name="BACKGROUND" value="161a19" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -840,9 +772,6 @@
       <value>
         <option name="FOREGROUND" value="354341" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -886,21 +815,10 @@
         <option name="FOREGROUND" value="229986" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,61 +837,45 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
       <value>
         <option name="EFFECT_COLOR" value="dee3ec" />
         <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="JSON.INVALID_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f23a3a" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="JSP_DIRECTIVE_NAME">
@@ -990,7 +892,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +917,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +931,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +944,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1094,7 +976,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1110,7 +991,6 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1126,7 +1006,6 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1136,7 +1015,7 @@
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1153,12 +1032,12 @@
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
@@ -1177,11 +1056,8 @@
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
@@ -1191,7 +1067,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,20 +1074,24 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="a1e6c1" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
@@ -1235,29 +1114,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="229986" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1140,16 @@
         <option name="BACKGROUND" value="161a19" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1491,31 +1187,16 @@
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,25 +1209,19 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
         <option name="FOREGROUND" value="a1e6c1" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1562,7 +1237,7 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
         <option name="BACKGROUND" value="161a19" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
@@ -1584,7 +1259,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1289,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="229986" />
@@ -1630,11 +1298,6 @@
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="a1e6c1" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1655,15 +1318,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="229986" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="229986" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,7 +1342,7 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
@@ -1693,11 +1356,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1705,11 +1363,8 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1735,7 +1390,7 @@
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="95C72A" />
+        <option name="FOREGROUND" value="95c72a" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
@@ -1792,18 +1447,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="229986" />
@@ -1812,4 +1455,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/laravel.icls
+++ b/jetbrains/laravel.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Laravel" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Laravel" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="2e2c2b" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,23 +15,23 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="FC6B0A" />
-    <option name="FILESTATUS_MODIFIED" value="FDCA49" />
+    <option name="FILESTATUS_MERGED" value="fc6b0a" />
+    <option name="FILESTATUS_MODIFIED" value="fdca49" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="FDCA49" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="FDCA49" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="fdca49" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="fdca49" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="FDCA49" />
-    <option name="GUTTER_BACKGROUND" value="2E2C2B" />
+    <option name="FILESTATUS_modifiedOutside" value="fdca49" />
+    <option name="GUTTER_BACKGROUND" value="2e2c2b" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
     <option name="MODIFIED_LINES_COLOR" value="" />
     <option name="NOTIFICATION_BACKGROUND" value="3d1a11" />
     <option name="READONLY_FRAGMENT_BACKGROUND" value="" />
-    <option name="RECURSIVE_CALL_ATTRIBUTES" value="574300" />
+    <option name="RECURSIVE_CALL_ATTRIBUTES" value="6e5e59" />
     <option name="RIGHT_MARGIN_COLOR" value="323232" />
     <option name="SELECTED_INDENT_GUIDE" value="505050" />
     <option name="SELECTED_TEARLINE_COLOR" value="787878" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="685d5c" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +216,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +307,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,29 +405,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,51 +460,51 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="FOREGROUND" value="ffa927" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +517,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +550,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="f23a3a" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +618,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +634,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,12 +647,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,22 +663,22 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FFC48C" />
+        <option name="FOREGROUND" value="ffc48c" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +703,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="FC6B0A" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="fc6b0a" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="615953" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +789,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -976,21 +863,27 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="JSON.INVALID_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f54e51" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +909,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +923,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +936,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +957,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="FC580C" />
+        <option name="FOREGROUND" value="fc580c" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FC580C" />
+        <option name="FOREGROUND" value="fc580c" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="FOREGROUND" value="fdca49" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1066,54 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="fdca49" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="fdca49" />
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="fae182" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="ffa927" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1122,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1143,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1162,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FC580C" />
+        <option name="FOREGROUND" value="fc580c" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1206,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1234,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="FOREGROUND" value="dedede" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1256,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1286,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1310,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="FFA927" />
+        <option name="EFFECT_COLOR" value="ffa927" />
+        <option name="ERROR_STRIPE_COLOR" value="ffa927" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="FFA927" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1339,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="615953" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,42 +1360,39 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FC580C" />
+        <option name="FOREGROUND" value="fc580c" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="FC6B0A" />
+        <option name="FOREGROUND" value="fc6b0a" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="FFC48C" />
+        <option name="FOREGROUND" value="ffc48c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1404,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1419,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="FDCA49" />
+        <option name="FOREGROUND" value="fdca49" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="FC580C" />
+        <option name="FOREGROUND" value="fc580c" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1444,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="FFA927" />
+        <option name="FOREGROUND" value="ffa927" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/lavender.icls
+++ b/jetbrains/lavender.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Lavender" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Lavender" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="29222e" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="B657FF" />
-    <option name="FILESTATUS_MODIFIED" value="F5B0EF" />
+    <option name="FILESTATUS_MERGED" value="b657ff" />
+    <option name="FILESTATUS_MODIFIED" value="f5b0ef" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="F5B0EF" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="F5B0EF" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f5b0ef" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="f5b0ef" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="F5B0EF" />
-    <option name="GUTTER_BACKGROUND" value="29222E" />
+    <option name="FILESTATUS_modifiedOutside" value="f5b0ef" />
+    <option name="GUTTER_BACKGROUND" value="29222e" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +216,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +307,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -400,9 +351,6 @@
       <value>
         <option name="FOREGROUND" value="4646f1" />
       </value>
-    </option>
-    <option name="Class">
-      <value />
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +366,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -456,27 +401,27 @@
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="E0CEED" />
+        <option name="FOREGROUND" value="e0ceed" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="E0CEED" />
+        <option name="FOREGROUND" value="e0ceed" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +433,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,51 +448,48 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
-        <option name="BACKGROUND" value="29222E" />
+        <option name="FOREGROUND" value="8e6da6" />
+        <option name="BACKGROUND" value="29222e" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +502,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +535,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="f54e51" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +566,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +579,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +603,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +619,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="E0CEED" />
+        <option name="FOREGROUND" value="e0ceed" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,12 +632,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,22 +648,22 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="E0CEED" />
+        <option name="FOREGROUND" value="e0ceed" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="A29DFA" />
+        <option name="FOREGROUND" value="a29dfa" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +688,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="B657FF" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="b657ff" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +742,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="614e6e" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +764,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +774,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +789,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +814,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +850,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +887,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +901,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +914,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +935,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="F25AE6" />
+        <option name="FOREGROUND" value="f25ae6" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F25AE6" />
+        <option name="FOREGROUND" value="f25ae6" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="E0CEED" />
+        <option name="FOREGROUND" value="e0ceed" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="E0CEED" />
+        <option name="FOREGROUND" value="e0ceed" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
-        <option name="BACKGROUND" value="29222E" />
+        <option name="FOREGROUND" value="f5b0ef" />
+        <option name="BACKGROUND" value="29222e" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="E0CEED" />
+        <option name="FOREGROUND" value="e0ceed" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1044,54 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="e0ceed" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f54e51" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="8e6da6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1100,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="29222E" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1121,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1140,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F25AE6" />
+        <option name="FOREGROUND" value="f25ae6" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1184,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1212,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="E0CEED" />
-        <option name="BACKGROUND" value="29222E" />
+        <option name="FOREGROUND" value="e0ceed" />
+        <option name="BACKGROUND" value="29222e" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1234,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1264,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1288,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="8E6DA6" />
+        <option name="EFFECT_COLOR" value="8e6da6" />
+        <option name="ERROR_STRIPE_COLOR" value="8e6da6" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="8E6DA6" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="29222E" />
+        <option name="BACKGROUND" value="29222e" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1317,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="614e6e" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,42 +1338,39 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="E0CEED" />
+        <option name="FOREGROUND" value="e0ceed" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F25AE6" />
+        <option name="FOREGROUND" value="f25ae6" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="B657FF" />
+        <option name="FOREGROUND" value="b657ff" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="A29DFA" />
+        <option name="FOREGROUND" value="a29dfa" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1382,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1397,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="F5B0EF" />
+        <option name="FOREGROUND" value="f5b0ef" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="F25AE6" />
+        <option name="FOREGROUND" value="f25ae6" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1422,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="8E6DA6" />
+        <option name="FOREGROUND" value="8e6da6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/legacy.icls
+++ b/jetbrains/legacy.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Legacy" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Legacy" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="14191f" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -17,14 +16,14 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_MERGED" value="ffffff" />
-    <option name="FILESTATUS_MODIFIED" value="FF410D" />
+    <option name="FILESTATUS_MODIFIED" value="ff410d" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="FF410D" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="FF410D" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="ff410d" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="ff410d" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="FF410D" />
+    <option name="FILESTATUS_modifiedOutside" value="ff410d" />
     <option name="GUTTER_BACKGROUND" value="14191f" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="748aa6" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -93,7 +91,7 @@
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +103,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="ffffff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,7 +266,7 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="CSS.IDENT">
@@ -312,7 +287,7 @@
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
@@ -333,18 +308,6 @@
     <option name="CSS.TAG_NAME">
       <value>
         <option name="FOREGROUND" value="748aa6" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +352,15 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="324357" />
+        <option name="FOREGROUND" value="41556b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -427,9 +381,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
         <option name="FOREGROUND" value="ffffff" />
@@ -437,13 +388,19 @@
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="324357" />
+        <option name="FOREGROUND" value="41556b" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
       <value>
         <option name="FOREGROUND" value="4d6785" />
         <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
+      <value>
+        <option name="FOREGROUND" value="7b9397" />
+        <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="DEFAULT_DOC_MARKUP">
@@ -454,6 +411,12 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
         <option name="FOREGROUND" value="748aa6" />
@@ -461,7 +424,7 @@
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
@@ -493,7 +456,7 @@
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="324357" />
+        <option name="FOREGROUND" value="41556b" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,7 +466,7 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
@@ -512,9 +475,6 @@
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
-      <value />
-    </option>
-    <option name="DEFAULT_SEMICOLON">
       <value />
     </option>
     <option name="DEFAULT_STATIC_FIELD">
@@ -529,8 +489,11 @@
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
@@ -593,15 +556,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +587,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +600,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +611,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +624,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -721,7 +658,7 @@
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -773,17 +710,14 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="ffffff" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
         <option name="BACKGROUND" value="14191f" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +728,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -841,9 +771,6 @@
         <option name="FOREGROUND" value="324357" />
       </value>
     </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
-    </option>
     <option name="JAVA_DOC_TAG">
       <value>
         <option name="EFFECT_TYPE" value="1" />
@@ -868,7 +795,7 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
@@ -886,21 +813,10 @@
         <option name="FOREGROUND" value="748aa6" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +835,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="ffffff" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +883,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +908,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +922,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +935,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,7 +956,7 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="C7F026" />
+        <option name="FOREGROUND" value="c7f026" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
@@ -1094,7 +967,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1104,13 +976,12 @@
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="C7F026" />
+        <option name="FOREGROUND" value="c7f026" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1120,13 +991,12 @@
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1163,7 +1033,7 @@
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
         <option name="BACKGROUND" value="14191f" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1180,18 +1050,14 @@
         <option name="FOREGROUND" value="aec2e0" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,21 +1065,23 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="aec2e0" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
@@ -1235,29 +1103,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="748aa6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1129,16 @@
         <option name="BACKGROUND" value="14191f" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1475,18 +1160,18 @@
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="C7F026" />
+        <option name="FOREGROUND" value="c7f026" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
@@ -1501,21 +1186,6 @@
         <option name="FOREGROUND" value="ffffff" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1540,13 +1210,7 @@
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1584,7 +1248,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1278,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="748aa6" />
@@ -1629,12 +1286,7 @@
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1655,15 +1307,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="748aa6" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="748aa6" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1684,18 +1336,13 @@
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="324357" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1707,9 +1354,6 @@
       <value>
         <option name="FOREGROUND" value="aec2e0" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1724,12 +1368,12 @@
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="C7F026" />
+        <option name="FOREGROUND" value="c7f026" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1396,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1411,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="FF410D" />
+        <option name="FOREGROUND" value="ff410d" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="C7F026" />
+        <option name="FOREGROUND" value="c7f026" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,18 +1436,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="748aa6" />
@@ -1812,4 +1444,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/mellow.icls
+++ b/jetbrains/mellow.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Mellow" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Mellow" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="36312c" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="1F8181" />
-    <option name="FILESTATUS_MODIFIED" value="F8BB39" />
+    <option name="FILESTATUS_MERGED" value="1f8181" />
+    <option name="FILESTATUS_MODIFIED" value="f8bb39" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="F8BB39" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="F8BB39" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f8bb39" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="f8bb39" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="F8BB39" />
-    <option name="GUTTER_BACKGROUND" value="36312C" />
+    <option name="FILESTATUS_modifiedOutside" value="f8bb39" />
+    <option name="GUTTER_BACKGROUND" value="36312c" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +216,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +307,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +352,15 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,26 +372,23 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -454,29 +405,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,12 +445,12 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,51 +460,48 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="FOREGROUND" value="f2bc79" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +514,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +547,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +578,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +591,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +615,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +631,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,38 +644,38 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +700,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="1F8181" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="1f8181" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +754,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +776,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +786,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +801,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +826,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +862,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +899,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +913,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +926,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +947,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="FOREGROUND" value="f8bb39" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1056,54 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f54e51" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="f2bc79" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1112,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="36312C" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1133,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1152,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1196,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1224,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
-        <option name="BACKGROUND" value="36312C" />
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1246,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1276,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1300,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="F2BC79" />
+        <option name="EFFECT_COLOR" value="f2bc79" />
+        <option name="ERROR_STRIPE_COLOR" value="f2bc79" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="F2BC79" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="36312C" />
+        <option name="BACKGROUND" value="36312c" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1329,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,59 +1350,56 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="1F8181" />
+        <option name="FOREGROUND" value="1f8181" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1409,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="F8BB39" />
+        <option name="FOREGROUND" value="f8bb39" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1434,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="F2BC79" />
+        <option name="FOREGROUND" value="f2bc79" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/mintchoc.icls
+++ b/jetbrains/mintchoc.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Mintchoc" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Mintchoc" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="2b221c" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,15 +15,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="008D62" />
-    <option name="FILESTATUS_MODIFIED" value="00E08C" />
+    <option name="FILESTATUS_MERGED" value="8d62" />
+    <option name="FILESTATUS_MODIFIED" value="e08c" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="00E08C" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="00E08C" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="e08c" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="e08c" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="00E08C" />
+    <option name="FILESTATUS_modifiedOutside" value="e08c" />
     <option name="GUTTER_BACKGROUND" value="2b221c" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +103,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="008D62" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +307,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +318,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,29 +405,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,45 +460,45 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="BACKGROUND" value="2b221c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +550,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +618,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -703,7 +634,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,12 +647,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,22 +663,22 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +703,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="008D62" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="8d62" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +713,40 @@
         <option name="BACKGROUND" value="2b221c" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="564439" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +789,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="008D62" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +865,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +929,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,60 +950,57 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,22 +1012,22 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
         <option name="BACKGROUND" value="2b221c" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1171,27 +1035,23 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1059,27 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1093,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1123,16 @@
         <option name="BACKGROUND" value="2b221c" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,53 +1148,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1192,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,7 +1220,7 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
         <option name="BACKGROUND" value="2b221c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
@@ -1584,7 +1242,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1272,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1296,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="9D8262" />
+        <option name="EFFECT_COLOR" value="9d8262" />
+        <option name="ERROR_STRIPE_COLOR" value="9d8262" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="9D8262" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1325,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="564439" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,42 +1346,39 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="BABABA" />
+        <option name="FOREGROUND" value="bababa" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="008D62" />
+        <option name="FOREGROUND" value="8d62" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1390,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1405,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="00E08C" />
+        <option name="FOREGROUND" value="e08c" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1430,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="9D8262" />
+        <option name="FOREGROUND" value="9d8262" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/mud.icls
+++ b/jetbrains/mud.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Mud" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Mud" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="403635" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,7 +15,7 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="FF9787" />
+    <option name="FILESTATUS_MERGED" value="ff9787" />
     <option name="FILESTATUS_MODIFIED" value="b5db99" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
     <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="b5db99" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="b5db99" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,7 +86,7 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="BNF_NUMBER">
@@ -106,9 +104,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="403635" />
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -296,18 +271,18 @@
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="CSS.NUMBER">
@@ -317,7 +292,7 @@
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +307,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +318,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,18 +337,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="b5db99" />
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,9 +405,15 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
@@ -476,7 +433,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -508,23 +465,20 @@
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
@@ -532,16 +486,19 @@
         <option name="FOREGROUND" value="b5db99" />
       </value>
     </option>
+    <option name="DEFAULT_TAG">
+      <value />
+    </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="BACKGROUND" value="403635" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +550,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +618,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,7 +647,7 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
@@ -732,7 +663,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -747,7 +678,7 @@
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +703,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="FF9787" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="ff9787" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +713,40 @@
         <option name="BACKGROUND" value="403635" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="c3b8b7" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -873,7 +794,7 @@
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +865,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +929,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1088,18 +955,17 @@
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="OC.NUMBER">
@@ -1110,12 +976,11 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="OC.STRING">
@@ -1126,17 +991,16 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,7 +1012,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1171,7 +1035,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1179,9 +1043,6 @@
       <value>
         <option name="FOREGROUND" value="ffffff" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
@@ -1191,7 +1052,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1059,32 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="b5db99" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="b5a5d5" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1098,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1128,16 @@
         <option name="BACKGROUND" value="403635" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,7 +1153,7 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1491,31 +1175,16 @@
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,13 +1197,13 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1543,15 +1212,9 @@
         <option name="FOREGROUND" value="b5db99" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1247,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1277,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="b5db99" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1301,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="FF9787" />
+        <option name="EFFECT_COLOR" value="ff9787" />
+        <option name="ERROR_STRIPE_COLOR" value="ff9787" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="FF9787" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,7 +1330,7 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
@@ -1693,11 +1344,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1708,17 +1354,14 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1735,7 +1378,7 @@
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
@@ -1792,24 +1435,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="FF9787" />
+        <option name="FOREGROUND" value="ff9787" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/otakon.icls
+++ b/jetbrains/otakon.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Otakon" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Otakon" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="171417" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,7 +15,7 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="F6E6EB" />
+    <option name="FILESTATUS_MERGED" value="f6e6eb" />
     <option name="FILESTATUS_MODIFIED" value="9eb2d9" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
     <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="9eb2d9" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="9eb2d9" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,7 +86,7 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="BNF_NUMBER">
@@ -106,9 +104,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="171417" />
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -296,18 +271,18 @@
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="CSS.NUMBER">
@@ -317,7 +292,7 @@
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +307,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +318,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,18 +337,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="9eb2d9" />
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,9 +405,15 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
@@ -476,7 +433,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -508,23 +465,20 @@
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
@@ -532,16 +486,19 @@
         <option name="FOREGROUND" value="9eb2d9" />
       </value>
     </option>
+    <option name="DEFAULT_TAG">
+      <value />
+    </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
         <option name="BACKGROUND" value="171417" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +550,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="f54e51" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +618,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,7 +647,7 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
@@ -732,7 +663,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -742,12 +673,12 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="B1A6CA" />
+        <option name="FOREGROUND" value="b1a6ca" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +703,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="F6E6EB" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="f6e6eb" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +713,40 @@
         <option name="BACKGROUND" value="171417" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="515166" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -873,7 +794,7 @@
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +865,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +929,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1088,18 +955,17 @@
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="OC.NUMBER">
@@ -1110,12 +976,11 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="OC.STRING">
@@ -1126,17 +991,16 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,7 +1012,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1171,7 +1035,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1179,9 +1043,6 @@
       <value>
         <option name="FOREGROUND" value="f9f3f9" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
@@ -1191,7 +1052,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1059,31 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="f9f3f9" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="9eb2d9" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f54e51" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1097,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="cacbdd" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1127,16 @@
         <option name="BACKGROUND" value="171417" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,7 +1152,7 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1491,31 +1174,16 @@
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,13 +1196,13 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1543,15 +1211,9 @@
         <option name="FOREGROUND" value="9eb2d9" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1246,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1276,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="9eb2d9" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1300,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="CACBDD" />
+        <option name="EFFECT_COLOR" value="cacbdd" />
+        <option name="ERROR_STRIPE_COLOR" value="cacbdd" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="CACBDD" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,7 +1329,7 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
@@ -1693,11 +1343,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1708,17 +1353,14 @@
         <option name="FOREGROUND" value="f9f3f9" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1735,12 +1377,12 @@
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="F6E6EB" />
+        <option name="FOREGROUND" value="f6e6eb" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="B1A6CA" />
+        <option name="FOREGROUND" value="b1a6ca" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1792,24 +1434,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="CACBDD" />
+        <option name="FOREGROUND" value="cacbdd" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/pastel.icls
+++ b/jetbrains/pastel.icls
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Pastel" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Pastel" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
@@ -16,15 +15,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="04C4A5" />
-    <option name="FILESTATUS_MODIFIED" value="C56C6C" />
+    <option name="FILESTATUS_MERGED" value="4c4a5" />
+    <option name="FILESTATUS_MODIFIED" value="c56c6c" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="C56C6C" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="C56C6C" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="c56c6c" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="c56c6c" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="C56C6C" />
+    <option name="FILESTATUS_modifiedOutside" value="c56c6c" />
     <option name="GUTTER_BACKGROUND" value="222222" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +103,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +307,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +318,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +352,15 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="444444" />
+        <option name="FOREGROUND" value="556b68" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,32 +372,35 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="444444" />
+        <option name="FOREGROUND" value="556b68" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
       <value>
         <option name="FOREGROUND" value="666666" />
         <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
+      <value>
+        <option name="FOREGROUND" value="7b9397" />
+        <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="DEFAULT_DOC_MARKUP">
@@ -454,14 +411,20 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
@@ -476,7 +439,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,12 +451,12 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="444444" />
+        <option name="FOREGROUND" value="556b68" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,45 +466,45 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
         <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +556,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="f54e51" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +587,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +600,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +624,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,23 +653,22 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
         <option name="FOREGROUND" value="444444" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -747,7 +683,7 @@
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +708,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="04C4A5" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="4c4a5" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +718,40 @@
         <option name="BACKGROUND" value="222222" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +762,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="444444" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +784,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +794,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +809,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +834,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +870,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +907,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +921,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +934,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,60 +955,57 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,7 +1017,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1163,7 +1032,7 @@
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
         <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1171,7 +1040,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1180,18 +1049,14 @@
         <option name="FOREGROUND" value="eeeeee" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1064,27 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="eeeeee" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1098,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="c5906c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1128,16 @@
         <option name="BACKGROUND" value="222222" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,53 +1153,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1197,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1247,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1277,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1301,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="C5906C" />
+        <option name="EFFECT_COLOR" value="c5906c" />
+        <option name="ERROR_STRIPE_COLOR" value="c5906c" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="C5906C" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1330,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="444444" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1708,34 +1354,31 @@
         <option name="FOREGROUND" value="eeeeee" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="04C4A5" />
+        <option name="FOREGROUND" value="4c4a5" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
@@ -1752,12 +1395,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1410,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="C56C6C" />
+        <option name="FOREGROUND" value="c56c6c" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1435,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="C5906C" />
+        <option name="FOREGROUND" value="c5906c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/patriot.icls
+++ b/jetbrains/patriot.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Patriot" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Patriot" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="2d3133" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="2E6FD9" />
-    <option name="FILESTATUS_MODIFIED" value="3790DE" />
+    <option name="FILESTATUS_MERGED" value="2e6fd9" />
+    <option name="FILESTATUS_MODIFIED" value="3790de" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="3790DE" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="3790DE" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="3790de" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="3790de" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="3790DE" />
-    <option name="GUTTER_BACKGROUND" value="2D3133" />
+    <option name="FILESTATUS_modifiedOutside" value="3790de" />
+    <option name="GUTTER_BACKGROUND" value="2d3133" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +216,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +307,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +352,15 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="515E66" />
+        <option name="FOREGROUND" value="515e66" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,26 +372,23 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="515E66" />
+        <option name="FOREGROUND" value="515e66" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -454,29 +405,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a495ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="CAD9E3" />
+        <option name="FOREGROUND" value="cad9e3" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="CAD9E3" />
+        <option name="FOREGROUND" value="cad9e3" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,12 +445,12 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="515E66" />
+        <option name="FOREGROUND" value="515e66" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,51 +460,51 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="FOREGROUND" value="bbbcc4" />
+        <option name="BACKGROUND" value="2d3133" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +517,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +550,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +618,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +634,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="CAD9E3" />
+        <option name="FOREGROUND" value="cad9e3" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,38 +647,38 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="515E66" />
+        <option name="FOREGROUND" value="515e66" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="CAD9E3" />
+        <option name="FOREGROUND" value="cad9e3" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="DE333C" />
+        <option name="FOREGROUND" value="de333c" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +703,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="2E6FD9" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="2e6fd9" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="515E66" />
+        <option name="FOREGROUND" value="515e66" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +789,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +865,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +929,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +950,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="CAD9E3" />
+        <option name="FOREGROUND" value="cad9e3" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="CAD9E3" />
+        <option name="FOREGROUND" value="cad9e3" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="FOREGROUND" value="3790de" />
+        <option name="BACKGROUND" value="2d3133" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="CAD9E3" />
+        <option name="FOREGROUND" value="cad9e3" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1059,47 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="cad9e3" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="bbbcc4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1108,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1129,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1148,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1192,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1220,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="CAD9E3" />
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="FOREGROUND" value="cad9e3" />
+        <option name="BACKGROUND" value="2d3133" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1242,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1272,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1296,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="BBBCC4" />
+        <option name="EFFECT_COLOR" value="bbbcc4" />
+        <option name="ERROR_STRIPE_COLOR" value="bbbcc4" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="BBBCC4" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2D3133" />
+        <option name="BACKGROUND" value="2d3133" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1325,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="515E66" />
+        <option name="FOREGROUND" value="515e66" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,59 +1346,56 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="CAD9E3" />
+        <option name="FOREGROUND" value="cad9e3" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="DE333C" />
+        <option name="FOREGROUND" value="de333c" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="515E66" />
+        <option name="FOREGROUND" value="515e66" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1405,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="3790DE" />
+        <option name="FOREGROUND" value="3790de" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="2E6FD9" />
+        <option name="FOREGROUND" value="2e6fd9" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1430,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="BBBCC4" />
+        <option name="FOREGROUND" value="bbbcc4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/peacock.icls
+++ b/jetbrains/peacock.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Peacock" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Peacock" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="292d30" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -25,21 +24,21 @@
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
     <option name="FILESTATUS_modifiedOutside" value="bcd42a" />
-    <option name="GUTTER_BACKGROUND" value="2b2a27" />
+    <option name="GUTTER_BACKGROUND" value="292d30" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
     <option name="MODIFIED_LINES_COLOR" value="" />
     <option name="NOTIFICATION_BACKGROUND" value="3d1a11" />
     <option name="READONLY_FRAGMENT_BACKGROUND" value="" />
-    <option name="RECURSIVE_CALL_ATTRIBUTES" value="574300" />
+    <option name="RECURSIVE_CALL_ATTRIBUTES" value="c0d5c1" />
     <option name="RIGHT_MARGIN_COLOR" value="323232" />
     <option name="SELECTED_INDENT_GUIDE" value="505050" />
     <option name="SELECTED_TEARLINE_COLOR" value="787878" />
-    <option name="SELECTION_BACKGROUND" value="161a1f" />
-    <option name="SELECTION_FOREGROUND" value="" />
+    <option name="SELECTION_BACKGROUND" value="c0d5c1" />
+    <option name="SELECTION_FOREGROUND" value="1e1e1e" />
     <option name="TEARLINE_COLOR" value="303134" />
-    <option name="WHITESPACES" value="505050" />
+    <option name="WHITESPACES" value="292d30" />
   </colors>
   <attributes>
     <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,21 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="90c93f" />
+      </value>
+    </option>
+    <option name="BASH.REDIRECTION">
+      <value>
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -106,12 +106,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2b2a27" />
+        <option name="BACKGROUND" value="3d5054" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +120,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="ff5d38" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +148,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +159,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +179,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +241,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -301,7 +278,7 @@
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -332,19 +309,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -374,18 +339,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="bcd42a" />
@@ -401,8 +354,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -428,7 +384,9 @@
       </value>
     </option>
     <option name="DEFAULT_COMMA">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="c0d5c1" />
+      </value>
     </option>
     <option name="DEFAULT_CONSTANT">
       <value>
@@ -454,9 +412,15 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
@@ -488,7 +452,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -508,13 +472,15 @@
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
+      </value>
+    </option>
+    <option name="DEFAULT_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
-      <value />
-    </option>
-    <option name="DEFAULT_SEMICOLON">
       <value />
     </option>
     <option name="DEFAULT_STATIC_FIELD">
@@ -532,9 +498,12 @@
         <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
+    <option name="DEFAULT_TAG">
+      <value />
+    </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="BACKGROUND" value="2b2a27" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
@@ -547,7 +516,7 @@
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="2b2a27" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -593,26 +562,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2b2a27" />
+        <option name="BACKGROUND" value="3d5054" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="2b2a27" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +593,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +606,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +630,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -772,18 +715,15 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="ff5d38" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="ff8e27" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="2b2a27" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +734,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -833,16 +769,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="7a7267" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +791,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -873,7 +806,7 @@
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +816,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +841,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="ff5d38" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +877,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +914,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +928,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +941,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1088,18 +967,17 @@
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="OC.NUMBER">
@@ -1110,12 +988,11 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="OC.STRING">
@@ -1126,12 +1003,11 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
@@ -1148,7 +1024,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1171,7 +1047,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1179,9 +1055,6 @@
       <value>
         <option name="FOREGROUND" value="ede0ce" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
@@ -1191,33 +1064,58 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
       <value>
-        <option name="FOREGROUND" value="8888c6" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="bcd42a" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
+        <option name="EFFECT_COLOR" value="90c62d" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="ff5d38" />
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="ff5d38" />
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_USAGE">
+      <value>
+        <option name="FOREGROUND" value="ff5d38" />
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1129,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,46 +1159,10 @@
         <option name="BACKGROUND" value="2b2a27" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="SASS_STRING">
@@ -1324,140 +1170,9 @@
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2b2a27" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,7 +1184,7 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1503,21 +1218,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
     <option name="Static field">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1543,15 +1243,9 @@
         <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1563,13 +1257,13 @@
     <option name="TEXT">
       <value>
         <option name="FOREGROUND" value="ede0ce" />
-        <option name="BACKGROUND" value="2b2a27" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2b2a27" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1278,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1308,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="bcd42a" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,25 +1332,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="26A6A6" />
+        <option name="EFFECT_COLOR" value="26a6a6" />
+        <option name="ERROR_STRIPE_COLOR" value="26a6a6" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="26A6A6" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2b2a27" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1693,11 +1375,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1708,17 +1385,14 @@
         <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1792,24 +1466,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/peacocks-in-space.icls
+++ b/jetbrains/peacocks-in-space.icls
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Peacocks In Space" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Peacocks In Space" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
@@ -16,15 +15,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="FF5D38" />
-    <option name="FILESTATUS_MODIFIED" value="BCD42A" />
+    <option name="FILESTATUS_MERGED" value="ff5d38" />
+    <option name="FILESTATUS_MODIFIED" value="bcd42a" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="BCD42A" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="BCD42A" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="bcd42a" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="bcd42a" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="BCD42A" />
+    <option name="FILESTATUS_modifiedOutside" value="bcd42a" />
     <option name="GUTTER_BACKGROUND" value="2b303b" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +103,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +307,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +318,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,14 +405,20 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
@@ -476,7 +433,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,45 +460,45 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="BACKGROUND" value="2b303b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +550,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +618,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,12 +647,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,7 +663,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -742,12 +673,12 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +703,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="FF5D38" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="ff5d38" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +713,40 @@
         <option name="BACKGROUND" value="2b303b" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="6e7a94" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +789,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +865,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +929,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,60 +950,57 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,7 +1012,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1163,7 +1027,7 @@
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
         <option name="BACKGROUND" value="2b303b" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1171,7 +1035,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1180,18 +1044,14 @@
         <option name="FOREGROUND" value="dee3ec" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1059,34 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="dee3ec" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1100,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1130,16 @@
         <option name="BACKGROUND" value="2b303b" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,53 +1155,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1199,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1249,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1279,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1303,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="26A6A6" />
+        <option name="EFFECT_COLOR" value="26a6a6" />
+        <option name="ERROR_STRIPE_COLOR" value="26a6a6" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="26A6A6" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1332,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="6e7a94" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1708,39 +1356,36 @@
         <option name="FOREGROUND" value="dee3ec" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="FF5D38" />
+        <option name="FOREGROUND" value="ff5d38" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1397,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1412,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="BCD42A" />
+        <option name="FOREGROUND" value="bcd42a" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1437,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="26A6A6" />
+        <option name="FOREGROUND" value="26a6a6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/peel.icls
+++ b/jetbrains/peel.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Peel" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Peel" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="23201c" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,7 +15,7 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="D3643B" />
+    <option name="FILESTATUS_MERGED" value="d3643b" />
     <option name="FILESTATUS_MODIFIED" value="f4d370" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
     <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f4d370" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="f4d370" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,7 +86,7 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="BNF_NUMBER">
@@ -106,9 +104,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="23201c" />
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -296,18 +271,18 @@
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="CSS.NUMBER">
@@ -317,7 +292,7 @@
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +307,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +318,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,18 +337,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f4d370" />
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,9 +405,15 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
@@ -466,17 +423,17 @@
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -508,23 +465,20 @@
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
@@ -532,16 +486,19 @@
         <option name="FOREGROUND" value="f4d370" />
       </value>
     </option>
+    <option name="DEFAULT_TAG">
+      <value />
+    </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="BACKGROUND" value="23201c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +550,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +618,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -703,7 +634,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,7 +647,7 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
@@ -732,22 +663,22 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +703,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="D3643B" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="d3643b" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +713,40 @@
         <option name="BACKGROUND" value="23201c" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="585146" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -873,7 +794,7 @@
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +865,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +929,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1088,18 +955,17 @@
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="OC.NUMBER">
@@ -1110,12 +976,11 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="OC.STRING">
@@ -1126,17 +991,16 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,17 +1012,17 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
@@ -1171,17 +1035,14 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
@@ -1191,7 +1052,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1059,49 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f4d370" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
+    </option>
+    <option name="PY.PREDEFINED_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="f4d370" />
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_USAGE">
+      <value>
+        <option name="FOREGROUND" value="d3643b" />
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1115,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1145,16 @@
         <option name="BACKGROUND" value="23201c" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,7 +1170,7 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1491,31 +1192,16 @@
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,13 +1214,13 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1543,15 +1229,9 @@
         <option name="FOREGROUND" value="f4d370" />
       </value>
     </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,7 +1242,7 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
         <option name="BACKGROUND" value="23201c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
@@ -1584,7 +1264,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1294,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="f4d370" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1318,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="94C7B6" />
+        <option name="EFFECT_COLOR" value="94c7b6" />
+        <option name="ERROR_STRIPE_COLOR" value="94c7b6" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="94C7B6" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,7 +1347,7 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
@@ -1693,11 +1361,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1705,20 +1368,17 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1735,12 +1395,12 @@
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="D3643B" />
+        <option name="FOREGROUND" value="d3643b" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1792,24 +1452,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="94C7B6" />
+        <option name="FOREGROUND" value="94c7b6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/piggy.icls
+++ b/jetbrains/piggy.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Piggy" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Piggy" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="1c1618" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,15 +15,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="FD6A5D" />
-    <option name="FILESTATUS_MODIFIED" value="FF453E" />
+    <option name="FILESTATUS_MERGED" value="fd6a5d" />
+    <option name="FILESTATUS_MODIFIED" value="ff453e" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="FF453E" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="FF453E" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="ff453e" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="ff453e" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="FF453E" />
+    <option name="FILESTATUS_modifiedOutside" value="ff453e" />
     <option name="GUTTER_BACKGROUND" value="1c1618" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +103,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +307,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +318,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,29 +405,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,45 +460,45 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="BACKGROUND" value="1c1618" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +550,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +618,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -703,7 +634,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,12 +647,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,22 +663,22 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="F52E62" />
+        <option name="FOREGROUND" value="f52e62" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +703,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="FD6A5D" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="fd6a5d" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +713,40 @@
         <option name="BACKGROUND" value="1c1618" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="3f3236" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +789,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +865,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +929,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,60 +950,57 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,22 +1012,22 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
         <option name="BACKGROUND" value="1c1618" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1171,27 +1035,23 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1059,27 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1093,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1123,16 @@
         <option name="BACKGROUND" value="1c1618" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,53 +1148,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1192,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,7 +1220,7 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
         <option name="BACKGROUND" value="1c1618" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
@@ -1584,7 +1242,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1272,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1296,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="FD6A5D" />
+        <option name="EFFECT_COLOR" value="fd6a5d" />
+        <option name="ERROR_STRIPE_COLOR" value="fd6a5d" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="FD6A5D" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1325,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="3f3236" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,42 +1346,39 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDEBE6" />
+        <option name="FOREGROUND" value="edebe6" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="F52E62" />
+        <option name="FOREGROUND" value="f52e62" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1390,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1405,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="FF453E" />
+        <option name="FOREGROUND" value="ff453e" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1430,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="FD6A5D" />
+        <option name="FOREGROUND" value="fd6a5d" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/potpourri.icls
+++ b/jetbrains/potpourri.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Potpourri" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Potpourri" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="2e2b2c" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="ED1153" />
-    <option name="FILESTATUS_MODIFIED" value="B866FA" />
+    <option name="FILESTATUS_MERGED" value="ed1153" />
+    <option name="FILESTATUS_MODIFIED" value="b866fa" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="B866FA" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="B866FA" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="b866fa" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="b866fa" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="B866FA" />
-    <option name="GUTTER_BACKGROUND" value="2E2B2C" />
+    <option name="FILESTATUS_modifiedOutside" value="b866fa" />
+    <option name="GUTTER_BACKGROUND" value="2e2b2c" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +216,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +307,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,29 +405,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,51 +460,51 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="FOREGROUND" value="ed1153" />
+        <option name="BACKGROUND" value="2e2b2c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +517,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +550,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +618,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +634,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,12 +647,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,22 +663,22 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="C491C4" />
+        <option name="FOREGROUND" value="c491c4" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +703,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="ED1153" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="ed1153" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="696363" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +789,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +865,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +929,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +950,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="C84FF0" />
+        <option name="FOREGROUND" value="c84ff0" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="C84FF0" />
+        <option name="FOREGROUND" value="c84ff0" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="FOREGROUND" value="b866fa" />
+        <option name="BACKGROUND" value="2e2b2c" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1059,49 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="b866fa" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1110,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1131,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1150,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="C84FF0" />
+        <option name="FOREGROUND" value="c84ff0" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1194,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1222,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="BACKGROUND" value="2e2b2c" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1244,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1274,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1298,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="ED1153" />
+        <option name="EFFECT_COLOR" value="ed1153" />
+        <option name="ERROR_STRIPE_COLOR" value="ed1153" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="ED1153" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2B2C" />
+        <option name="BACKGROUND" value="2e2b2c" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1327,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="696363" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,42 +1348,39 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="F8F8F2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="C84FF0" />
+        <option name="FOREGROUND" value="c84ff0" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="C491C4" />
+        <option name="FOREGROUND" value="c491c4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1392,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1407,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="B866FA" />
+        <option name="FOREGROUND" value="b866fa" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="C84FF0" />
+        <option name="FOREGROUND" value="c84ff0" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1432,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="ED1153" />
+        <option name="FOREGROUND" value="ed1153" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/rainbow.icls
+++ b/jetbrains/rainbow.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Rainbow" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Rainbow" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="16181a" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,7 +15,7 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="EF746F" />
+    <option name="FILESTATUS_MERGED" value="ef746f" />
     <option name="FILESTATUS_MODIFIED" value="c78feb" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
     <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="c78feb" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="c78feb" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="3fb4c5" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,7 +86,7 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="BNF_NUMBER">
@@ -106,9 +104,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="16181a" />
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -296,7 +271,7 @@
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
@@ -307,7 +282,7 @@
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="CSS.NUMBER">
@@ -317,7 +292,7 @@
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -335,18 +310,6 @@
         <option name="FOREGROUND" value="3fb4c5" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
@@ -355,7 +318,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,18 +337,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="c78feb" />
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -453,6 +404,12 @@
     </option>
     <option name="DEFAULT_DOT">
       <value />
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
@@ -476,7 +433,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -514,23 +471,23 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
         <option name="FOREGROUND" value="c78feb" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
@@ -541,7 +498,7 @@
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +550,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +594,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +605,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +618,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,7 +647,7 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
@@ -732,7 +663,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -742,12 +673,12 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="B3CC57" />
+        <option name="FOREGROUND" value="b3cc57" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +703,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="EF746F" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="ef746f" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +713,40 @@
         <option name="BACKGROUND" value="16181a" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -840,9 +764,6 @@
       <value>
         <option name="FOREGROUND" value="424c55" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -886,21 +807,10 @@
         <option name="FOREGROUND" value="3fb4c5" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +877,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +929,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1094,7 +961,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1110,7 +976,6 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1126,7 +991,6 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1136,7 +1000,7 @@
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1180,9 +1044,6 @@
         <option name="FOREGROUND" value="c7d0d9" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
         <option name="FOREGROUND" value="c78feb" />
@@ -1191,7 +1052,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,20 +1059,19 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="c7d0d9" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="c78feb" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.KEYWORD_ARGUMENT">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
@@ -1235,29 +1094,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="3fb4c5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1120,16 @@
         <option name="BACKGROUND" value="16181a" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1491,31 +1167,16 @@
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,25 +1189,19 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
         <option name="FOREGROUND" value="c78feb" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1584,7 +1239,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1269,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="3fb4c5" />
@@ -1630,11 +1278,6 @@
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="c78feb" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1655,15 +1298,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="3fb4c5" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="3fb4c5" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,7 +1322,7 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
@@ -1693,11 +1336,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1707,9 +1345,6 @@
       <value>
         <option name="FOREGROUND" value="c7d0d9" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1735,12 +1370,12 @@
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="EF746F" />
+        <option name="FOREGROUND" value="ef746f" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="B3CC57" />
+        <option name="FOREGROUND" value="b3cc57" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1792,18 +1427,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="3fb4c5" />
@@ -1812,4 +1435,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/revelation.icls
+++ b/jetbrains/revelation.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Revelation" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Revelation" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="2e2c2b" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="617FA0" />
-    <option name="FILESTATUS_MODIFIED" value="FFBB29" />
+    <option name="FILESTATUS_MERGED" value="617fa0" />
+    <option name="FILESTATUS_MODIFIED" value="ffbb29" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="FFBB29" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="FFBB29" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="ffbb29" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="ffbb29" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="FFBB29" />
-    <option name="GUTTER_BACKGROUND" value="2E2C2B" />
+    <option name="FILESTATUS_modifiedOutside" value="ffbb29" />
+    <option name="GUTTER_BACKGROUND" value="2e2c2b" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="3d5054" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +216,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +307,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,29 +405,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,51 +460,51 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="FOREGROUND" value="c2dcf2" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +517,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +550,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="3d5054" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +618,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +634,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,12 +647,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,22 +663,22 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="4E5D84" />
+        <option name="FOREGROUND" value="4e5d84" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +703,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="617FA0" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="617fa0" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="7b726b" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +789,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +865,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +929,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +950,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="FOREGROUND" value="ffbb29" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1059,61 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ffbb29" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="77999f" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="c2dcf2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1122,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1143,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1162,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1206,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1234,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="FOREGROUND" value="dedede" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1256,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1286,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1310,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="C2DCF2" />
+        <option name="EFFECT_COLOR" value="c2dcf2" />
+        <option name="ERROR_STRIPE_COLOR" value="c2dcf2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="C2DCF2" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1339,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="7b726b" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,42 +1360,39 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="4E5D84" />
+        <option name="FOREGROUND" value="4e5d84" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1404,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1419,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1444,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="C2DCF2" />
+        <option name="FOREGROUND" value="c2dcf2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/shrek.icls
+++ b/jetbrains/shrek.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Shrek" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Shrek" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="222222" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="81e911" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="bfb59b" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -106,9 +104,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="222222" />
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="857a5e" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -335,18 +310,6 @@
         <option name="FOREGROUND" value="bfb59b" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
@@ -374,18 +337,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="81e911" />
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -427,9 +381,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
         <option name="FOREGROUND" value="857a5e" />
@@ -453,6 +404,12 @@
     </option>
     <option name="DEFAULT_DOT">
       <value />
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
@@ -514,9 +471,6 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
         <option name="FOREGROUND" value="857a5e" />
@@ -531,6 +485,9 @@
       <value>
         <option name="FOREGROUND" value="81e911" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
@@ -593,15 +550,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +594,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +605,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +618,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -742,7 +673,7 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="B2DE62" />
+        <option name="FOREGROUND" value="b2de62" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
@@ -773,17 +704,14 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="857a5e" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
         <option name="BACKGROUND" value="222222" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +722,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -840,9 +764,6 @@
       <value>
         <option name="FOREGROUND" value="555555" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -886,21 +807,10 @@
         <option name="FOREGROUND" value="bfb59b" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="857a5e" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +877,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +929,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1094,7 +961,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1110,7 +976,6 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1126,7 +991,6 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1180,9 +1044,6 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
         <option name="FOREGROUND" value="81e911" />
@@ -1191,7 +1052,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,20 +1059,31 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="857a5e" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="81e911" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
@@ -1235,29 +1106,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="bfb59b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1132,16 @@
         <option name="BACKGROUND" value="222222" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1503,21 +1191,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
     <option name="Static field">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1541,12 +1214,6 @@
     <option name="String">
       <value>
         <option name="FOREGROUND" value="81e911" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1584,7 +1251,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1281,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="bfb59b" />
@@ -1630,11 +1290,6 @@
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="81e911" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1655,15 +1310,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="bfb59b" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="bfb59b" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1693,11 +1348,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1707,9 +1357,6 @@
       <value>
         <option name="FOREGROUND" value="ffffff" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1740,7 +1387,7 @@
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="B2DE62" />
+        <option name="FOREGROUND" value="b2de62" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1792,18 +1439,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="bfb59b" />
@@ -1812,4 +1447,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/slate.icls
+++ b/jetbrains/slate.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Slate" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Slate" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="19191f" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,7 +15,7 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="89A7B1" />
+    <option name="FILESTATUS_MERGED" value="89a7b1" />
     <option name="FILESTATUS_MODIFIED" value="9eb2d9" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
     <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="9eb2d9" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="9eb2d9" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="566981" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,7 +86,7 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="BNF_NUMBER">
@@ -106,9 +104,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="19191f" />
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -296,7 +271,7 @@
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
@@ -307,7 +282,7 @@
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="CSS.NUMBER">
@@ -317,7 +292,7 @@
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -335,18 +310,6 @@
         <option name="FOREGROUND" value="566981" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
@@ -355,7 +318,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,18 +337,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="9eb2d9" />
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -453,6 +404,12 @@
     </option>
     <option name="DEFAULT_DOT">
       <value />
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
@@ -476,7 +433,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -514,22 +471,24 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
         <option name="FOREGROUND" value="9eb2d9" />
+      </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value>
+        <option name="FOREGROUND" value="3c3f41" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
@@ -541,7 +500,7 @@
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +552,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +583,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +596,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +607,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +620,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,7 +649,7 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
@@ -732,7 +665,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -747,7 +680,7 @@
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +705,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="89A7B1" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="89a7b1" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +715,40 @@
         <option name="BACKGROUND" value="19191f" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -840,9 +766,6 @@
       <value>
         <option name="FOREGROUND" value="515166" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -886,21 +809,10 @@
         <option name="FOREGROUND" value="566981" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +831,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +879,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +904,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +918,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +931,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1094,7 +963,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1110,7 +978,6 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1126,7 +993,6 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1136,7 +1002,7 @@
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1180,9 +1046,6 @@
         <option name="FOREGROUND" value="ebebf4" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
         <option name="FOREGROUND" value="9eb2d9" />
@@ -1191,7 +1054,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,20 +1061,31 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ebebf4" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="9eb2d9" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
@@ -1235,29 +1108,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="566981" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1134,16 @@
         <option name="BACKGROUND" value="19191f" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1491,31 +1181,16 @@
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,25 +1203,19 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
         <option name="FOREGROUND" value="9eb2d9" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1584,7 +1253,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1283,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="566981" />
@@ -1630,11 +1292,6 @@
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="9eb2d9" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1655,15 +1312,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="566981" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="566981" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,7 +1336,7 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
@@ -1693,11 +1350,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1707,9 +1359,6 @@
       <value>
         <option name="FOREGROUND" value="ebebf4" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1735,7 +1384,7 @@
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="89A7B1" />
+        <option name="FOREGROUND" value="89a7b1" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
@@ -1792,18 +1441,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="566981" />
@@ -1812,4 +1449,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/slime.icls
+++ b/jetbrains/slime.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Slime" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Slime" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="292d30" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,27 +15,27 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="9FB3C2" />
-    <option name="FILESTATUS_MODIFIED" value="FAFFDB" />
+    <option name="FILESTATUS_MERGED" value="9fb3c2" />
+    <option name="FILESTATUS_MODIFIED" value="faffdb" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="FAFFDB" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="FAFFDB" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="faffdb" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="faffdb" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="FAFFDB" />
-    <option name="GUTTER_BACKGROUND" value="292D30" />
+    <option name="FILESTATUS_modifiedOutside" value="faffdb" />
+    <option name="GUTTER_BACKGROUND" value="292d30" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
     <option name="MODIFIED_LINES_COLOR" value="" />
     <option name="NOTIFICATION_BACKGROUND" value="3d1a11" />
     <option name="READONLY_FRAGMENT_BACKGROUND" value="" />
-    <option name="RECURSIVE_CALL_ATTRIBUTES" value="574300" />
+    <option name="RECURSIVE_CALL_ATTRIBUTES" value="85991d" />
     <option name="RIGHT_MARGIN_COLOR" value="323232" />
     <option name="SELECTED_INDENT_GUIDE" value="505050" />
     <option name="SELECTED_TEARLINE_COLOR" value="787878" />
-    <option name="SELECTION_BACKGROUND" value="161a1f" />
+    <option name="SELECTION_BACKGROUND" value="2f7454" />
     <option name="SELECTION_FOREGROUND" value="" />
     <option name="TEARLINE_COLOR" value="303134" />
     <option name="WHITESPACES" value="505050" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="a9ae92" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="3d5054" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,18 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="CLASS_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="80c0ba" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +151,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +162,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +182,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +221,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -258,12 +244,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -279,9 +259,19 @@
         <option name="FOREGROUND" value="cdcd00" />
       </value>
     </option>
+    <option name="CONSTRUCTOR_CALL_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="faffdb" />
+      </value>
+    </option>
+    <option name="CONSTRUCTOR_DECLARATION_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="bbb529" />
+      </value>
+    </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +281,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +322,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +352,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +367,15 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F5A63" />
+        <option name="FOREGROUND" value="4f5a63" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,26 +387,28 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_COMMA">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="4cd6a3" />
+      </value>
     </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F5A63" />
+        <option name="FOREGROUND" value="4f5a63" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -454,46 +425,61 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="bbb529" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="86bba8" />
+        <option name="BACKGROUND" value="292d30" />
+        <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="dee3ec" />
-        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="FOREGROUND" value="ec0e00" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F5A63" />
+        <option name="FOREGROUND" value="4f5a63" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="b4fae6" />
+        <option name="BACKGROUND" value="292d30" />
+        <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,51 +489,56 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="4cd6a3" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
+      </value>
+    </option>
+    <option name="DEFAULT_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="bbb529" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="a9ae92" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
-        <option name="BACKGROUND" value="292D30" />
+        <option name="FOREGROUND" value="9fb3c2" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,31 +551,32 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
     <option name="DOC_COMMENT_TAG_VALUE">
       <value>
         <option name="FOREGROUND" value="80919f" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="DUPLICATE_FROM_SERVER">
@@ -593,26 +585,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="3d5054" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +616,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +629,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +653,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +669,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,38 +682,38 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F5A63" />
+        <option name="FOREGROUND" value="4f5a63" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +738,55 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="9FB3C2" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="9fb3c2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
+      </value>
+    </option>
+    <option name="INTERFACE_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="bbb529" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -831,76 +795,54 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="JAVA_COMMA">
+    <option name="JAVA_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="8c9faf" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F5A63" />
+        <option name="FOREGROUND" value="778895" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="JAVA_DOC_MARKUP">
-      <value />
+      <value>
+        <option name="FONT_TYPE" value="2" />
+      </value>
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
+        <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="JAVA_INVALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="6a8759" />
-        <option name="EFFECT_COLOR" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="JAVA_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="9FB3C2" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="808080" />
+        <option name="FOREGROUND" value="6e7c85" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="bbb529" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="JAVA_STRING">
       <value>
-        <option name="FOREGROUND" value="6a8759" />
-      </value>
-    </option>
-    <option name="JAVA_VALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9FB3C2" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="a9ae92" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +861,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +897,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +934,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +948,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +961,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,172 +982,177 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="C7AF3F" />
+        <option name="FOREGROUND" value="c7af3f" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="C7AF3F" />
+        <option name="FOREGROUND" value="c7af3f" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
+      </value>
+    </option>
+    <option name="PARAMETER_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="bbb529" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
-        <option name="BACKGROUND" value="292D30" />
+        <option name="FOREGROUND" value="faffdb" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
-    <option name="PY.BUILTIN_NAME">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="8888c6" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="86bba8" />
+        <option name="BACKGROUND" value="292d30" />
+        <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="bbb529" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ec0e00" />
+        <option name="EFFECT_COLOR" value="3c3f41" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bbb529" />
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="4cd6a3" />
+      </value>
+    </option>
+    <option name="PY.STRING.U">
+      <value>
+        <option name="FOREGROUND" value="86bba8" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1161,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="292D30" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1182,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1201,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="C7AF3F" />
+        <option name="FOREGROUND" value="c7af3f" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1245,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1273,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
-        <option name="BACKGROUND" value="292D30" />
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,12 +1295,12 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="507874" />
+        <option name="FOREGROUND" value="faffdb" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="TYPO">
@@ -1615,31 +1326,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1350,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="9FB3C2" />
+        <option name="EFFECT_COLOR" value="9fb3c2" />
+        <option name="ERROR_STRIPE_COLOR" value="9fb3c2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="9FB3C2" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="292D30" />
+        <option name="BACKGROUND" value="292d30" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1379,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F5A63" />
+        <option name="FOREGROUND" value="4f5a63" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,59 +1400,56 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="FOREGROUND" value="ffffff" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="C7AF3F" />
+        <option name="FOREGROUND" value="c7af3f" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4F5A63" />
+        <option name="FOREGROUND" value="4f5a63" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1459,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="FAFFDB" />
+        <option name="FOREGROUND" value="faffdb" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="C7AF3F" />
+        <option name="FOREGROUND" value="c7af3f" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1484,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="9FB3C2" />
+        <option name="FOREGROUND" value="9fb3c2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/snappy.icls
+++ b/jetbrains/snappy.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Snappy" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Snappy" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="393939" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="4ea1df" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="f66153" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -106,9 +104,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="393939" />
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="f66153" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -335,18 +310,6 @@
         <option name="FOREGROUND" value="f66153" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
@@ -374,18 +337,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="4ea1df" />
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -427,9 +381,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
         <option name="FOREGROUND" value="f66153" />
@@ -453,6 +404,12 @@
     </option>
     <option name="DEFAULT_DOT">
       <value />
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
@@ -514,9 +471,6 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
         <option name="FOREGROUND" value="f66153" />
@@ -531,6 +485,9 @@
       <value>
         <option name="FOREGROUND" value="4ea1df" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
@@ -593,15 +550,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="f5162e" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +594,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +605,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +618,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -773,17 +704,14 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="f66153" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
         <option name="BACKGROUND" value="393939" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +722,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -840,9 +764,6 @@
       <value>
         <option name="FOREGROUND" value="696969" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -886,21 +807,10 @@
         <option name="FOREGROUND" value="f66153" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="f66153" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +877,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +929,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1094,7 +961,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1110,7 +976,6 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1126,7 +991,6 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1180,9 +1044,6 @@
         <option name="FOREGROUND" value="e3e2e0" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
         <option name="FOREGROUND" value="4ea1df" />
@@ -1191,7 +1052,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,20 +1059,31 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="f66153" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="e3e2e0" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="4ea1df" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
@@ -1235,29 +1106,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="f66153" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1132,16 @@
         <option name="BACKGROUND" value="393939" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1503,21 +1191,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
     <option name="Static field">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1541,12 +1214,6 @@
     <option name="String">
       <value>
         <option name="FOREGROUND" value="4ea1df" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1584,7 +1251,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1281,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="f66153" />
@@ -1630,11 +1290,6 @@
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="4ea1df" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1655,15 +1310,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="f66153" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f66153" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1693,11 +1348,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1707,9 +1357,6 @@
       <value>
         <option name="FOREGROUND" value="e3e2e0" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1792,18 +1439,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="f66153" />
@@ -1812,4 +1447,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/solarflare.icls
+++ b/jetbrains/solarflare.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Solarflare" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Solarflare" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="222222" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,15 +15,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="FF4E50" />
-    <option name="FILESTATUS_MODIFIED" value="EDE574" />
+    <option name="FILESTATUS_MERGED" value="ff4e50" />
+    <option name="FILESTATUS_MODIFIED" value="ede574" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="EDE574" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="EDE574" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="ede574" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="ede574" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="EDE574" />
+    <option name="FILESTATUS_modifiedOutside" value="ede574" />
     <option name="GUTTER_BACKGROUND" value="222222" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +103,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +239,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +307,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +318,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,14 +405,20 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
@@ -476,7 +433,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,45 +460,45 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +550,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +618,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,12 +647,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,7 +663,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -742,12 +673,12 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FC913A" />
+        <option name="FOREGROUND" value="fc913a" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +703,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="FF4E50" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="ff4e50" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +713,40 @@
         <option name="BACKGROUND" value="222222" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="777777" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +789,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +865,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +929,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,60 +950,57 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,7 +1012,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1163,7 +1027,7 @@
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
         <option name="BACKGROUND" value="222222" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1171,7 +1035,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1180,18 +1044,14 @@
         <option name="FOREGROUND" value="e3e2e0" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1059,36 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="e3e2e0" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ede574" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1102,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1132,16 @@
         <option name="BACKGROUND" value="222222" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,53 +1157,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1201,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1251,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1281,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1305,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="FF4E50" />
+        <option name="EFFECT_COLOR" value="ff4e50" />
+        <option name="ERROR_STRIPE_COLOR" value="ff4e50" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="FF4E50" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1334,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="777777" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1708,39 +1358,36 @@
         <option name="FOREGROUND" value="e3e2e0" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="FC913A" />
+        <option name="FOREGROUND" value="fc913a" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1399,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1414,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="EDE574" />
+        <option name="FOREGROUND" value="ede574" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1439,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="FF4E50" />
+        <option name="FOREGROUND" value="ff4e50" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/sourlick.icls
+++ b/jetbrains/sourlick.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Sourlick" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Sourlick" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="2e2c2b" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="8AC27A" />
-    <option name="FILESTATUS_MODIFIED" value="E4FF33" />
+    <option name="FILESTATUS_MERGED" value="8ac27a" />
+    <option name="FILESTATUS_MODIFIED" value="e4ff33" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="E4FF33" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="E4FF33" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="e4ff33" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="e4ff33" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="E4FF33" />
-    <option name="GUTTER_BACKGROUND" value="2E2C2B" />
+    <option name="FILESTATUS_modifiedOutside" value="e4ff33" />
+    <option name="GUTTER_BACKGROUND" value="2e2c2b" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +216,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +266,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +307,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,29 +405,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +445,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,51 +460,51 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="FOREGROUND" value="d2eb31" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +517,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +550,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="f5162e" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +594,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +618,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +634,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,12 +647,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,22 +663,22 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="EDF252" />
+        <option name="FOREGROUND" value="edf252" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +703,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="8AC27A" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="8ac27a" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +757,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="615953" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +779,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +789,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +804,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +865,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +929,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +950,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="FC580C" />
+        <option name="FOREGROUND" value="fc580c" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FC580C" />
+        <option name="FOREGROUND" value="fc580c" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="FOREGROUND" value="e4ff33" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1059,56 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="e4ff33" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="d2eb31" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1117,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1138,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1157,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FC580C" />
+        <option name="FOREGROUND" value="fc580c" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1201,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1229,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="FOREGROUND" value="dedede" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1251,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1281,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1305,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="D2EB31" />
+        <option name="EFFECT_COLOR" value="d2eb31" />
+        <option name="ERROR_STRIPE_COLOR" value="d2eb31" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="D2EB31" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1334,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="615953" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,42 +1355,39 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FC580C" />
+        <option name="FOREGROUND" value="fc580c" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="8AC27A" />
+        <option name="FOREGROUND" value="8ac27a" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="EDF252" />
+        <option name="FOREGROUND" value="edf252" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1399,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1414,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="E4FF33" />
+        <option name="FOREGROUND" value="e4ff33" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="FC580C" />
+        <option name="FOREGROUND" value="fc580c" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1439,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="D2EB31" />
+        <option name="FOREGROUND" value="d2eb31" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/spearmint.icls
+++ b/jetbrains/spearmint.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Spearmint" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Spearmint" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="e1f0ee" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="25808A" />
-    <option name="FILESTATUS_MODIFIED" value="4CD7E0" />
+    <option name="FILESTATUS_MERGED" value="25808a" />
+    <option name="FILESTATUS_MODIFIED" value="4cd7e0" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="4CD7E0" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="4CD7E0" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="4cd7e0" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="4cd7e0" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="4CD7E0" />
-    <option name="GUTTER_BACKGROUND" value="E1F0EE" />
+    <option name="FILESTATUS_modifiedOutside" value="4cd7e0" />
+    <option name="GUTTER_BACKGROUND" value="e1f0ee" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,16 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
-    <option name="BASH.INTERNAL_COMMAND">
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +83,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +101,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +115,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="25808A" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +143,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +154,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +174,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +213,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +234,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +253,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +263,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +304,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +334,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +349,9 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
-    </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="93C7C0" />
+        <option name="FOREGROUND" value="93c7c0" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,26 +363,23 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="93C7C0" />
+        <option name="FOREGROUND" value="93c7c0" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -456,12 +398,12 @@
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
@@ -476,7 +418,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,12 +430,12 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="93C7C0" />
+        <option name="FOREGROUND" value="93c7c0" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,51 +445,48 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="FOREGROUND" value="69adb5" />
+        <option name="BACKGROUND" value="e1f0ee" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +499,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +532,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +563,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +576,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +600,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -716,23 +629,23 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="93C7C0" />
+        <option name="FOREGROUND" value="93c7c0" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -742,12 +655,12 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +685,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="25808A" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="25808a" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +739,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="93C7C0" />
+        <option name="FOREGROUND" value="93c7c0" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +761,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +771,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +786,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +811,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="25808A" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +847,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +884,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +898,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +911,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,72 +932,69 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="199FA8" />
+        <option name="FOREGROUND" value="199fa8" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="199FA8" />
+        <option name="FOREGROUND" value="199fa8" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1163,15 +1009,15 @@
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="FOREGROUND" value="4cd7e0" />
+        <option name="BACKGROUND" value="e1f0ee" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1180,18 +1026,14 @@
         <option name="FOREGROUND" value="719692" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1041,54 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="719692" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="3bc7b8" />
       </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="41556b" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="69adb5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1097,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1118,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1137,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="199FA8" />
+        <option name="FOREGROUND" value="199fa8" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1181,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1563,13 +1210,13 @@
     <option name="TEXT">
       <value>
         <option name="FOREGROUND" value="719692" />
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1231,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1261,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1285,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="69ADB5" />
+        <option name="EFFECT_COLOR" value="69adb5" />
+        <option name="ERROR_STRIPE_COLOR" value="69adb5" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="69ADB5" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="E1F0EE" />
+        <option name="BACKGROUND" value="e1f0ee" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1314,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="93C7C0" />
+        <option name="FOREGROUND" value="93c7c0" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1708,56 +1338,53 @@
         <option name="FOREGROUND" value="719692" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="199FA8" />
+        <option name="FOREGROUND" value="199fa8" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="25808A" />
+        <option name="FOREGROUND" value="25808a" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="93C7C0" />
+        <option name="FOREGROUND" value="93c7c0" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1394,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="4CD7E0" />
+        <option name="FOREGROUND" value="4cd7e0" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="199FA8" />
+        <option name="FOREGROUND" value="199fa8" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1419,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="69ADB5" />
+        <option name="FOREGROUND" value="69adb5" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/stark.icls
+++ b/jetbrains/stark.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Stark" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Stark" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="2e2c2b" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="F03113" />
-    <option name="FILESTATUS_MODIFIED" value="FFBB29" />
+    <option name="FILESTATUS_MERGED" value="f03113" />
+    <option name="FILESTATUS_MODIFIED" value="ffbb29" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="FFBB29" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="FFBB29" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="ffbb29" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="ffbb29" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="FFBB29" />
-    <option name="GUTTER_BACKGROUND" value="2E2C2B" />
+    <option name="FILESTATUS_modifiedOutside" value="ffbb29" />
+    <option name="GUTTER_BACKGROUND" value="2e2c2b" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,19 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="aaaaaa" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +86,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +104,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +118,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F03113" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +146,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +157,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +177,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +216,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +237,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +256,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,12 +266,12 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
@@ -307,17 +282,17 @@
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -335,27 +310,15 @@
         <option name="FOREGROUND" value="aaaaaa" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +337,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +352,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +372,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,6 +405,12 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
         <option name="FOREGROUND" value="aaaaaa" />
@@ -461,22 +418,22 @@
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -503,7 +460,7 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
@@ -514,40 +471,40 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
         <option name="FOREGROUND" value="aaaaaa" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +517,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +550,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +581,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +594,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +605,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +618,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +634,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,12 +647,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,22 +663,22 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +703,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="F03113" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="f03113" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -840,9 +764,6 @@
       <value>
         <option name="FOREGROUND" value="615953" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -868,7 +789,7 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
@@ -886,21 +807,10 @@
         <option name="FOREGROUND" value="aaaaaa" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +829,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="F03113" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +877,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +902,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +916,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +929,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,7 +950,7 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
@@ -1094,7 +961,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1104,13 +970,12 @@
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1120,13 +985,12 @@
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1136,14 +1000,14 @@
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
@@ -1153,18 +1017,18 @@
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="FOREGROUND" value="ffbb29" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
@@ -1177,21 +1041,17 @@
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,20 +1059,24 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ffbb29" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
@@ -1224,7 +1088,7 @@
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
@@ -1235,20 +1099,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="aaaaaa" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1110,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1131,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1475,47 +1156,32 @@
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,25 +1194,19 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1562,14 +1222,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="FOREGROUND" value="dedede" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1244,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1274,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="aaaaaa" />
@@ -1629,17 +1282,12 @@
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1655,20 +1303,20 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="aaaaaa" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="aaaaaa" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2E2C2B" />
+        <option name="BACKGROUND" value="2e2c2b" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1327,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="615953" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,11 +1348,8 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="DEDEDE" />
+        <option name="FOREGROUND" value="dedede" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1724,23 +1364,23 @@
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="F03113" />
+        <option name="FOREGROUND" value="f03113" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1392,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1407,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="FFBB29" />
+        <option name="FOREGROUND" value="ffbb29" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="617FA0" />
+        <option name="FOREGROUND" value="617fa0" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,18 +1432,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="aaaaaa" />
@@ -1812,4 +1440,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/super.icls
+++ b/jetbrains/super.icls
@@ -1,14 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Super" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Super" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="CONSOLE_FONT_NAME" value="Serif" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="15191d" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +16,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="D60257" />
-    <option name="FILESTATUS_MODIFIED" value="F7A21B" />
+    <option name="FILESTATUS_MERGED" value="d60257" />
+    <option name="FILESTATUS_MODIFIED" value="f7a21b" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="F7A21B" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="F7A21B" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="f7a21b" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="f7a21b" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="F7A21B" />
-    <option name="GUTTER_BACKGROUND" value="15191D" />
+    <option name="FILESTATUS_modifiedOutside" value="f7a21b" />
+    <option name="GUTTER_BACKGROUND" value="15191d" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +53,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +60,21 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="bfe5eb" />
+      </value>
+    </option>
+    <option name="BASH.REDIRECTION">
+      <value>
+        <option name="FOREGROUND" value="5d67ad" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +89,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +107,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +121,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="D60257" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +149,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +160,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +180,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +219,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +240,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +259,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,12 +269,12 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
@@ -307,17 +285,17 @@
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -335,27 +313,15 @@
         <option name="FOREGROUND" value="5d67ad" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +340,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +355,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +375,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,6 +408,12 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
         <option name="FOREGROUND" value="5d67ad" />
@@ -461,7 +421,7 @@
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
@@ -476,7 +436,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -503,7 +463,7 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
@@ -514,40 +474,40 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
         <option name="FOREGROUND" value="5d67ad" />
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +520,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +553,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +584,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +597,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +608,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +621,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -716,12 +650,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,7 +666,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -747,7 +681,7 @@
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +706,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="D60257" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="d60257" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -840,9 +767,6 @@
       <value>
         <option name="FOREGROUND" value="465360" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -868,7 +792,7 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
@@ -886,21 +810,10 @@
         <option name="FOREGROUND" value="5d67ad" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +832,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="D60257" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +880,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +905,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +919,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +932,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,7 +953,7 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
@@ -1094,7 +964,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1104,13 +973,12 @@
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1120,13 +988,12 @@
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1136,14 +1003,14 @@
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
@@ -1163,8 +1030,8 @@
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
-        <option name="BACKGROUND" value="15191D" />
+        <option name="FOREGROUND" value="f7a21b" />
+        <option name="BACKGROUND" value="15191d" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
@@ -1180,18 +1047,14 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,20 +1062,31 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f7a21b" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
@@ -1224,7 +1098,7 @@
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
@@ -1235,20 +1109,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="5d67ad" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1120,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="15191D" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1141,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1475,47 +1166,32 @@
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,25 +1204,19 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1563,13 +1233,13 @@
     <option name="TEXT">
       <value>
         <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1254,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1284,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="5d67ad" />
@@ -1629,17 +1292,12 @@
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1655,20 +1313,20 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="5d67ad" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="5d67ad" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="15191D" />
+        <option name="BACKGROUND" value="15191d" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1337,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="465360" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1707,9 +1360,6 @@
       <value>
         <option name="FOREGROUND" value="ffffff" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1724,18 +1374,18 @@
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="D60257" />
+        <option name="FOREGROUND" value="d60257" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
@@ -1752,12 +1402,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1417,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="F7A21B" />
+        <option name="FOREGROUND" value="f7a21b" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,18 +1442,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="5d67ad" />
@@ -1812,4 +1450,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/tonic.icls
+++ b/jetbrains/tonic.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Tonic" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Tonic" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="2a2f31" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,15 +15,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="B8CD44" />
-    <option name="FILESTATUS_MODIFIED" value="B8CD44" />
+    <option name="FILESTATUS_MERGED" value="b8cd44" />
+    <option name="FILESTATUS_MODIFIED" value="b8cd44" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="B8CD44" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="B8CD44" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="b8cd44" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="b8cd44" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="B8CD44" />
+    <option name="FILESTATUS_modifiedOutside" value="b8cd44" />
     <option name="GUTTER_BACKGROUND" value="2a2f31" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,21 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="bfe5eb" />
+      </value>
+    </option>
+    <option name="BASH.REDIRECTION">
+      <value>
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +88,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +105,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +120,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +148,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +159,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +179,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +241,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +258,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +268,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +309,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +320,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +339,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,8 +354,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -418,21 +374,18 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -454,14 +407,20 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
@@ -476,7 +435,7 @@
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,7 +447,7 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
@@ -503,45 +462,45 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
         <option name="BACKGROUND" value="2a2f31" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +552,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +583,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +596,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +620,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -716,12 +649,12 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="HTML_COMMENT">
@@ -732,7 +665,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="HTML_TAG">
@@ -742,12 +675,12 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="75A1A4" />
+        <option name="FOREGROUND" value="75a1a4" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +705,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="B8CD44" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="b8cd44" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +715,40 @@
         <option name="BACKGROUND" value="2a2f31" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +759,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="4a5356" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +781,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +791,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +806,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +831,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +867,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +904,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +918,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +931,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,60 +952,57 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,7 +1014,7 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="PHP_TAG">
@@ -1163,7 +1029,7 @@
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
         <option name="BACKGROUND" value="2a2f31" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1171,7 +1037,7 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1180,18 +1046,14 @@
         <option name="FOREGROUND" value="eeeeee" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1061,36 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="b8cd44" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1104,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="ef6e44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1134,16 @@
         <option name="BACKGROUND" value="2a2f31" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,53 +1159,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1203,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1584,7 +1253,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1283,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1307,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="EF6E44" />
+        <option name="EFFECT_COLOR" value="ef6e44" />
+        <option name="ERROR_STRIPE_COLOR" value="ef6e44" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="EF6E44" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1336,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="4a5356" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1708,39 +1360,36 @@
         <option name="FOREGROUND" value="eeeeee" />
       </value>
     </option>
-    <option name="XML_TAG_DATA">
-      <value />
-    </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="75A1A4" />
+        <option name="FOREGROUND" value="75a1a4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1752,12 +1401,12 @@
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1416,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="B8CD44" />
+        <option name="FOREGROUND" value="b8cd44" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1441,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="EF6E44" />
+        <option name="FOREGROUND" value="ef6e44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/tribal.icls
+++ b/jetbrains/tribal.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Tribal" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Tribal" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="19191d" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,21 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="64aeb3" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="bfe5eb" />
+      </value>
+    </option>
+    <option name="BASH.REDIRECTION">
+      <value>
+        <option name="FOREGROUND" value="5f5582" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -106,9 +106,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="19191d" />
@@ -123,14 +120,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="5f5582" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +148,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +159,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +179,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -256,12 +239,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -335,18 +312,6 @@
         <option name="FOREGROUND" value="5f5582" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
@@ -374,18 +339,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="64aeb3" />
@@ -401,8 +354,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -427,9 +383,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
         <option name="FOREGROUND" value="5f5582" />
@@ -453,6 +406,12 @@
     </option>
     <option name="DEFAULT_DOT">
       <value />
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
@@ -514,9 +473,6 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
         <option name="FOREGROUND" value="5f5582" />
@@ -531,6 +487,9 @@
       <value>
         <option name="FOREGROUND" value="64aeb3" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
@@ -593,15 +552,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +583,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +596,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +607,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +620,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -773,17 +706,14 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="5f5582" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
         <option name="BACKGROUND" value="19191d" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +724,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -840,9 +766,6 @@
       <value>
         <option name="FOREGROUND" value="4a4a54" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -886,21 +809,10 @@
         <option name="FOREGROUND" value="5f5582" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +831,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="5f5582" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +879,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +904,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +918,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +931,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1094,7 +963,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1110,7 +978,6 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1126,7 +993,6 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1180,9 +1046,6 @@
         <option name="FOREGROUND" value="ffffff" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
         <option name="FOREGROUND" value="64aeb3" />
@@ -1191,7 +1054,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,20 +1061,31 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="5f5582" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="64aeb3" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
@@ -1235,29 +1108,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="5f5582" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1134,16 @@
         <option name="BACKGROUND" value="19191d" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1503,21 +1193,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
     <option name="Static field">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1541,12 +1216,6 @@
     <option name="String">
       <value>
         <option name="FOREGROUND" value="64aeb3" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1584,7 +1253,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1283,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="5f5582" />
@@ -1630,11 +1292,6 @@
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="64aeb3" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1655,15 +1312,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="5f5582" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="5f5582" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1693,11 +1350,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1707,9 +1359,6 @@
       <value>
         <option name="FOREGROUND" value="ffffff" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1792,18 +1441,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="5f5582" />
@@ -1812,4 +1449,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/tron.icls
+++ b/jetbrains/tron.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Tron" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Tron" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="14191f" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,20 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="6ee2ff" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="748aa6" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -106,9 +105,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="14191f" />
@@ -123,14 +119,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="ffffff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +147,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +158,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +178,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -256,12 +238,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -335,18 +311,6 @@
         <option name="FOREGROUND" value="748aa6" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
@@ -374,18 +338,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="6ee2ff" />
@@ -401,8 +353,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -427,9 +382,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
         <option name="FOREGROUND" value="ffffff" />
@@ -453,6 +405,12 @@
     </option>
     <option name="DEFAULT_DOT">
       <value />
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
@@ -514,9 +472,6 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
         <option name="FOREGROUND" value="ffffff" />
@@ -531,6 +486,9 @@
       <value>
         <option name="FOREGROUND" value="6ee2ff" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
@@ -593,15 +551,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +582,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +595,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +606,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +619,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -773,17 +705,14 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="ffffff" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
         <option name="BACKGROUND" value="14191f" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +723,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -840,9 +765,6 @@
       <value>
         <option name="FOREGROUND" value="324357" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -886,21 +808,10 @@
         <option name="FOREGROUND" value="748aa6" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +830,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="ffffff" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +878,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +903,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +917,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +930,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1094,7 +962,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1110,7 +977,6 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1126,7 +992,6 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1180,9 +1045,6 @@
         <option name="FOREGROUND" value="aec2e0" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
         <option name="FOREGROUND" value="6ee2ff" />
@@ -1191,7 +1053,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,21 +1060,30 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="6ee2ff" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="6ee2ff" />
       </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
@@ -1235,29 +1105,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="748aa6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1131,16 @@
         <option name="BACKGROUND" value="14191f" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1503,21 +1190,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
     <option name="Static field">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1541,12 +1213,6 @@
     <option name="String">
       <value>
         <option name="FOREGROUND" value="6ee2ff" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1584,7 +1250,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1280,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="748aa6" />
@@ -1630,11 +1289,6 @@
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="6ee2ff" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1655,15 +1309,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="748aa6" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="748aa6" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1693,11 +1347,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1707,9 +1356,6 @@
       <value>
         <option name="FOREGROUND" value="aec2e0" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1792,18 +1438,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="748aa6" />
@@ -1812,4 +1446,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/turnip.icls
+++ b/jetbrains/turnip.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Turnip" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Turnip" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="1a1b1d" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,15 +15,15 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="487D76" />
-    <option name="FILESTATUS_MODIFIED" value="E8DA5E" />
+    <option name="FILESTATUS_MERGED" value="487d76" />
+    <option name="FILESTATUS_MODIFIED" value="e8da5e" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="E8DA5E" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="E8DA5E" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="e8da5e" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="e8da5e" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="E8DA5E" />
+    <option name="FILESTATUS_modifiedOutside" value="e8da5e" />
     <option name="GUTTER_BACKGROUND" value="1a1b1d" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,20 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="92b55f" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +87,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -105,9 +104,6 @@
       <value>
         <option name="FOREGROUND" value="629755" />
       </value>
-    </option>
-    <option name="BNF_TOKEN">
-      <value />
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
@@ -123,14 +119,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="487D76" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +147,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +158,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +178,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -258,12 +240,6 @@
         <option name="FOREGROUND" value="f8f8f0" />
       </value>
     </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
@@ -281,7 +257,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +267,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,19 +308,7 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
@@ -355,7 +319,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +338,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +353,15 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,26 +373,23 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -454,29 +406,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,12 +446,12 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,45 +461,45 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="BACKGROUND" value="1a1b1d" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -593,15 +551,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +582,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +595,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +619,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -703,7 +635,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,38 +648,38 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,9 +704,9 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="487D76" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="487d76" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -782,47 +714,40 @@
         <option name="BACKGROUND" value="1a1b1d" />
       </value>
     </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
-    </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +758,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +780,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +790,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +805,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +830,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="487D76" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +866,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +903,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +917,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +930,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,60 +951,57 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1148,22 +1013,22 @@
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
         <option name="BACKGROUND" value="1a1b1d" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
@@ -1171,27 +1036,23 @@
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,25 +1060,34 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1231,33 +1101,17 @@
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1131,16 @@
         <option name="BACKGROUND" value="1a1b1d" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1469,53 +1156,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1200,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,7 +1228,7 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
         <option name="BACKGROUND" value="1a1b1d" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
@@ -1584,7 +1250,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,26 +1280,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1650,20 +1304,20 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="92B55F" />
+        <option name="EFFECT_COLOR" value="92b55f" />
+        <option name="ERROR_STRIPE_COLOR" value="92b55f" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="92B55F" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1679,23 +1333,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,59 +1354,56 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="487D76" />
+        <option name="FOREGROUND" value="487d76" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1413,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="E8DA5E" />
+        <option name="FOREGROUND" value="e8da5e" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1438,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="92B55F" />
+        <option name="FOREGROUND" value="92b55f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/yule.icls
+++ b/jetbrains/yule.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Yule" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Yule" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="2b2a27" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -16,16 +15,16 @@
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_MERGED" value="D63131" />
-    <option name="FILESTATUS_MODIFIED" value="EBB626" />
+    <option name="FILESTATUS_MERGED" value="d63131" />
+    <option name="FILESTATUS_MODIFIED" value="ebb626" />
     <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="EBB626" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="EBB626" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="ebb626" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="ebb626" />
     <option name="FILESTATUS_UNKNOWN" value="d1675a" />
     <option name="FILESTATUS_addedOutside" value="629755" />
     <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="EBB626" />
-    <option name="GUTTER_BACKGROUND" value="2B2A27" />
+    <option name="FILESTATUS_modifiedOutside" value="ebb626" />
+    <option name="GUTTER_BACKGROUND" value="2b2a27" />
     <option name="INDENT_GUIDE" value="3c3e42" />
     <option name="LINE_NUMBERS_COLOR" value="888888" />
     <option name="METHOD_SEPARATORS_COLOR" value="4d4d4d" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,20 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.HERE_DOC">
       <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
+      <value />
+    </option>
+    <option name="BASH.REDIRECTION">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="39b81f" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -88,12 +87,12 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="BNF_NUMBER">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="BNF_RULE">
@@ -106,12 +105,9 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="403635" />
       </value>
     </option>
     <option name="BROWSEWORDATCARET">
@@ -123,14 +119,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="D63131" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +147,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +158,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +178,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -235,12 +217,12 @@
     </option>
     <option name="CONSOLE_OUTPUT">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
       </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
@@ -256,12 +238,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -281,7 +257,7 @@
     </option>
     <option name="CSS.COLOR">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -291,33 +267,33 @@
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="CSS.IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
@@ -332,30 +308,18 @@
     </option>
     <option name="CSS.TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -374,21 +338,9 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
@@ -401,12 +353,15 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -418,26 +373,23 @@
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -454,29 +406,35 @@
     <option name="DEFAULT_DOT">
       <value />
     </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
     <option name="DEFAULT_INSTANCE_METHOD">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
@@ -488,12 +446,12 @@
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
@@ -503,51 +461,51 @@
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_METHOD">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="FOREGROUND" value="39b81f" />
+        <option name="BACKGROUND" value="2b2a27" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
         <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
@@ -560,25 +518,25 @@
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
         <option name="ERROR_STRIPE_COLOR" value="8f5247" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
         <option name="ERROR_STRIPE_COLOR" value="656e76" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
         <option name="ERROR_STRIPE_COLOR" value="447152" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
         <option name="ERROR_STRIPE_COLOR" value="43698d" />
       </value>
     </option>
@@ -593,26 +551,25 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="403635" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8c8c8c" />
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
@@ -625,8 +582,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,26 +595,17 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,31 +619,15 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
     </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="HAML_RUBY_CODE">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
@@ -703,7 +635,7 @@
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
     <option name="HAML_TEXT">
@@ -716,38 +648,38 @@
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
         <option name="EFFECT_COLOR" value="287bde" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -772,57 +704,50 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="D63131" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="d63131" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="Invalid string escape">
@@ -833,16 +758,13 @@
     </option>
     <option name="JAVA_COMMA">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -858,7 +780,7 @@
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
@@ -868,12 +790,12 @@
     </option>
     <option name="JAVA_NUMBER">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="JAVA_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="JAVA_STRING">
@@ -883,24 +805,13 @@
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
-      </value>
-    </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +830,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="D63131" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -978,19 +866,18 @@
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +903,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +917,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,12 +930,11 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="Map key">
@@ -1083,115 +951,108 @@
     </option>
     <option name="Number">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="OC.CPP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="OC.NUMBER">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="OC.STRING">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="FOREGROUND" value="ebb626" />
+        <option name="BACKGROUND" value="2b2a27" />
         <option name="EFFECT_COLOR" value="ff0000" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
-    </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,56 +1060,62 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ebb626" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value />
+    </option>
+    <option name="PY.PREDEFINED_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="ebb626" />
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_USAGE">
+      <value>
+        <option name="FOREGROUND" value="8888c6" />
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="4cd6a3" />
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
         <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
+        <option name="FOREGROUND" value="39b81f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1257,55 +1124,19 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" value="2b2a27" />
       </value>
     </option>
     <option name="SASS_NUMBER">
@@ -1314,150 +1145,14 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
     </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
         <option name="ERROR_STRIPE_COLOR" value="246e00" />
       </value>
     </option>
@@ -1469,53 +1164,38 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
       </value>
     </option>
     <option name="Static field">
@@ -1528,30 +1208,24 @@
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="String">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1562,14 +1236,14 @@
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="FOREGROUND" value="ede0ce" />
+        <option name="BACKGROUND" value="2b2a27" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
         <option name="EFFECT_COLOR" value="56ac48" />
         <option name="ERROR_STRIPE_COLOR" value="425f44" />
       </value>
@@ -1584,7 +1258,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,31 +1288,20 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
       </value>
     </option>
     <option name="VELOCITY_STRING">
@@ -1650,25 +1312,25 @@
     </option>
     <option name="Valid string escape">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="39B81F" />
+        <option name="EFFECT_COLOR" value="39b81f" />
+        <option name="ERROR_STRIPE_COLOR" value="39b81f" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="ERROR_STRIPE_COLOR" value="39B81F" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="2B2A27" />
+        <option name="BACKGROUND" value="2b2a27" />
         <option name="ERROR_STRIPE_COLOR" value="c55450" />
       </value>
     </option>
@@ -1679,23 +1341,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
@@ -1705,59 +1362,56 @@
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="EDE0CE" />
+        <option name="FOREGROUND" value="ede0ce" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="D63131" />
+        <option name="FOREGROUND" value="d63131" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="7A7267" />
+        <option name="FOREGROUND" value="7a7267" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
@@ -1767,12 +1421,12 @@
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="EBB626" />
+        <option name="FOREGROUND" value="ebb626" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
@@ -1792,24 +1446,11 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
-        <option name="FOREGROUND" value="39B81F" />
+        <option name="FOREGROUND" value="39b81f" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
   </attributes>
 </scheme>
-

--- a/jetbrains/zacks.icls
+++ b/jetbrains/zacks.icls
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scheme name="Zacks" version="124" parent_scheme="Default">
-  <option name="LINE_SPACING" value="1.4" />
-  <option name="EDITOR_FONT_SIZE" value="10" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Zacks" version="142" parent_scheme="Default">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="292d38" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />
     <option name="CARET_COLOR" value="7b7d83" />
     <option name="CARET_ROW_COLOR" value="" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="2b303b" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="222222" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
@@ -53,12 +52,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ATTR_INTERNAL_CALL_ID">
-      <value>
-        <option name="FOREGROUND" value="a2cff5" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="c81414" />
@@ -66,14 +59,18 @@
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="c57633" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
+      <value />
     </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BASH.INTERNAL_COMMAND">
       <value>
-        <option name="FOREGROUND" value="b0c95" />
+        <option name="FOREGROUND" value="bfe5eb" />
+      </value>
+    </option>
+    <option name="BASH.REDIRECTION">
+      <value>
+        <option name="FOREGROUND" value="ff6a38" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="BNF_EXTERNAL">
@@ -106,9 +103,6 @@
         <option name="FOREGROUND" value="629755" />
       </value>
     </option>
-    <option name="BNF_TOKEN">
-      <value />
-    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="222222" />
@@ -123,14 +117,13 @@
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="ff6a38" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -152,9 +145,7 @@
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
       <value>
@@ -165,12 +156,6 @@
     <option name="CONDITIONALLY_NOT_COMPILED">
       <value>
         <option name="FOREGROUND" value="536c46" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLACK_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
@@ -191,11 +176,6 @@
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="33cccc" />
-      </value>
-    </option>
-    <option name="CONSOLE_DARKGRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="555555" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -256,12 +236,6 @@
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="f8f8f0" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="7f00" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
@@ -335,18 +309,6 @@
         <option name="FOREGROUND" value="ff6a38" />
       </value>
     </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="287bde" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="589df6" />
-        <option name="EFFECT_COLOR" value="589df6" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
@@ -374,18 +336,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="bcd42a" />
@@ -401,8 +351,11 @@
         <option name="FOREGROUND" value="4646f1" />
       </value>
     </option>
-    <option name="Class">
-      <value />
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
@@ -427,9 +380,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="DEFAULT_COMMA">
-      <value />
-    </option>
     <option name="DEFAULT_CONSTANT">
       <value>
         <option name="FOREGROUND" value="ff6a38" />
@@ -453,6 +403,12 @@
     </option>
     <option name="DEFAULT_DOT">
       <value />
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a975ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
     </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
@@ -514,9 +470,6 @@
     <option name="DEFAULT_PARENTHS">
       <value />
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value />
-    </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
         <option name="FOREGROUND" value="ff6a38" />
@@ -531,6 +484,9 @@
       <value>
         <option name="FOREGROUND" value="bcd42a" />
       </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value />
     </option>
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
@@ -593,15 +549,14 @@
     <option name="ENUM_CONST">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -625,8 +580,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="f49810" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
@@ -638,12 +593,6 @@
     <option name="GRADLE_CHANGE_CONFLICT">
       <value>
         <option name="FOREGROUND" value="db4233" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="GRADLE_NO_CHANGE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
@@ -655,9 +604,6 @@
       <value>
         <option name="FOREGROUND" value="6a8759" />
       </value>
-    </option>
-    <option name="Groovy method declaration">
-      <value />
     </option>
     <option name="Groovydoc comment">
       <value>
@@ -671,27 +617,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9458" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="HAML_FILTER">
       <value />
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value />
-    </option>
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
@@ -773,17 +703,14 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="ff6a38" />
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
         <option name="BACKGROUND" value="222222" />
       </value>
-    </option>
-    <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
-      <value />
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
@@ -794,25 +721,21 @@
     <option name="INTELLIJ_LOCAL_CHANGE">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="IVAR">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion first part">
       <value>
         <option name="FOREGROUND" value="1a5746" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Implicit conversion second part">
       <value>
         <option name="FOREGROUND" value="1e7866" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="Instance field">
@@ -840,9 +763,6 @@
       <value>
         <option name="FOREGROUND" value="777777" />
       </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value />
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
@@ -886,21 +806,10 @@
         <option name="FOREGROUND" value="ff6a38" />
       </value>
     </option>
-    <option name="JFLEX.JAVA_CODE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
     <option name="JFLEX.OPTION_KEYWORD">
       <value>
         <option name="FOREGROUND" value="c69d9d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX.OPTION_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX.OPTION_SIGN">
@@ -919,55 +828,32 @@
         <option name="FOREGROUND" value="658665" />
       </value>
     </option>
-    <option name="JFLEX_COMMA">
-      <value />
-    </option>
     <option name="JFLEX_MACROS">
       <value>
         <option name="FOREGROUND" value="c63c41" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
         <option name="FOREGROUND" value="ff6a38" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_OPTION_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JFLEX_REGEXP_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_CLASS_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_REGEXP_SYMBOL">
       <value>
         <option name="FOREGROUND" value="999975" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JFLEX_STATE_REF">
       <value>
         <option name="FOREGROUND" value="658665" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="JS.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -990,7 +876,6 @@
     <option name="LABEL">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
@@ -1016,24 +901,9 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-      </value>
-    </option>
     <option name="LOG_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
       </value>
     </option>
     <option name="List/map to object conversion">
@@ -1045,13 +915,10 @@
     <option name="MACRONAME">
       <value>
         <option name="FOREGROUND" value="908b25" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MACRO_PARAMETER">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
@@ -1061,7 +928,6 @@
     <option name="MESSAGE_ARGUMENT">
       <value>
         <option name="FOREGROUND" value="c4b3a3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
@@ -1094,7 +960,6 @@
     <option name="OC.DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="80b000" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.KEYWORD">
@@ -1110,7 +975,6 @@
     <option name="OC.PROPERTY">
       <value>
         <option name="FOREGROUND" value="cdbcac" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC.SELFSUPERTHIS">
@@ -1126,7 +990,6 @@
     <option name="OC.STRUCT_FIELD">
       <value>
         <option name="FOREGROUND" value="9373a5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="OC_FORMAT_TOKEN">
@@ -1180,9 +1043,6 @@
         <option name="FOREGROUND" value="f0f0f0" />
       </value>
     </option>
-    <option name="PROPERTIES.VALID_STRING_ESCAPE">
-      <value />
-    </option>
     <option name="PROPERTIES.VALUE">
       <value>
         <option name="FOREGROUND" value="bcd42a" />
@@ -1191,7 +1051,6 @@
     <option name="PROTOCOL_REFERENCE">
       <value>
         <option name="FOREGROUND" value="219598" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
@@ -1199,20 +1058,31 @@
         <option name="FOREGROUND" value="8888c6" />
       </value>
     </option>
-    <option name="REGEXP.BRACES">
+    <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ff6a38" />
       </value>
     </option>
-    <option name="REGEXP.BRACKETS">
+    <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FOREGROUND" value="ff6a38" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
+    <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="bcd42a" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f5162e" />
+        <option name="EFFECT_COLOR" value="c81414" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="bfe5eb" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
@@ -1235,29 +1105,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="REGEXP.QUOTE_CHARACTER">
       <value>
         <option name="FOREGROUND" value="ff6a38" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.REDUNDANT_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="9396c0" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="1" />
       </value>
@@ -1277,183 +1131,16 @@
         <option name="BACKGROUND" value="222222" />
       </value>
     </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="bc9455" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="SASS_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="cc7833" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
     <option name="SASS_NUMBER">
       <value>
         <option name="FOREGROUND" value="a5c261" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="SASS_RULE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-      </value>
-    </option>
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="a5c261" />
       </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CIDR">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_CVS plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Evaluation fixes.">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA Test Sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_IDEA sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JDK">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_JavaEE openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Ruby">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_Weblogic sources">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_community except testdata">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_copyright">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_evaluation">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except JavaEE">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_everywhere except junit4">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_flask plugin">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_foreach debugging ">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_gdb device timeout on start">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_idea openapi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_ignore">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_introduce typedef">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_javascript">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_junit 4 features">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_libraries.except.jdk">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_lldb-92">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_platform API">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_psi">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_runtime.classes">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_stl">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_svnPlugins">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_type name construction">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_types resolve">
-      <value />
-    </option>
-    <option name="SCOPE_KEY_util-rt">
-      <value />
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
@@ -1503,21 +1190,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Scala Type Alias">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
-    <option name="Scala Type parameter">
-      <value>
-        <option name="FOREGROUND" value="4e807d" />
-      </value>
-    </option>
     <option name="Static field">
       <value>
         <option name="FOREGROUND" value="d0d0ff" />
@@ -1541,12 +1213,6 @@
     <option name="String">
       <value>
         <option name="FOREGROUND" value="bcd42a" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_PARAMATER">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="TAPESTRY_COMPONENT_TAG">
@@ -1584,7 +1250,6 @@
     <option name="TYPEDEF">
       <value>
         <option name="FOREGROUND" value="c7c8f5" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
@@ -1615,12 +1280,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="VELOCITY_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="ff6a38" />
@@ -1630,11 +1289,6 @@
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="bcd42a" />
-      </value>
-    </option>
-    <option name="VELOCITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
@@ -1655,15 +1309,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_TYPE" value="2" />
         <option name="ERROR_STRIPE_COLOR" value="8c8c00" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="ff6a38" />
-        <option name="EFFECT_TYPE" value="1" />
         <option name="ERROR_STRIPE_COLOR" value="ff6a38" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1693,11 +1347,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="6d9cbe" />
-      </value>
-    </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="e8bf6a" />
@@ -1707,9 +1356,6 @@
       <value>
         <option name="FOREGROUND" value="f0f0f0" />
       </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
@@ -1792,18 +1438,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="osmorc.attributeName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="osmorc.directiveName">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="osmorc.headerName">
       <value>
         <option name="FOREGROUND" value="ff6a38" />
@@ -1812,4 +1446,3 @@
     </option>
   </attributes>
 </scheme>
-


### PR DESCRIPTION
Set jetbrains themes to PyCharm IDE. #198 

* [x] - Arstotzka
* [x] - Azure
* [x] - Bold
* [x] - Boxuk
* [x] - Carbonight
* [x] - Chocolate
* [x] - Crisp
* [x] - Darkside
* [x] - Earthsong
* [x] - Freshcut
* [x] - Frontier
* [x] - Github
* [x] - Gloom
* [x] - Glowfish
* [x] - Goldfish
* [x] - Grunge
* [x] - Halflife
* [x] - Heroku
* [x] - Hyrule
* [x] - Iceberg
* [x] - Ironleaf (new theme)
* [x] - Juicy
* [x] - Keen
* [x] - Kiwi
* [x] - Laravel
* [x] - Lavender
* [x] - Legacy
* [x] - Mellow
* [x] - Mintchoc
* [x] - Mud
* [x] - Otakon
* [x] - Pastel
* [x] - Patriot
* [x] - Peacock
* [x] - Peacocks-in-space
* [x] - Peel
* [x] - Piggy
* [x] - Potpourri
* [x] - Rainbow
* [x] - Revelation
* [x] - Shrek
* [x] - Slate
* [x] - Slime
* [x] - Snappy
* [x] - Solarflare
* [x] - Sourlick
* [x] - Spearmint
* [x] - Stark
* [x] - Super
* [x] - Tonic
* [x] - Tribal
* [x] - Tron
* [x] - Turnip
* [x] - Yule
* [x] - Zacks

#### Added new theme: Ironleaf