### PR TITLE
Updates /vim/colors/ to use correct cterm colors.

### DIFF
--- a/vim/colors/arstotzka.vim
+++ b/vim/colors/arstotzka.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#211f1e  guifg=#EDEBE6    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#EDEBE6   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#211f1e  guifg=#EDEBE6    gui=none ctermbg=16 ctermfg=230
+hi NonText     guibg=bg  guifg=#EDEBE6   ctermbg=bg ctermfg=230
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#A2A797   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#A2A797   ctermbg=bg ctermfg=144
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#3f3a36  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#3f3a36  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#a5e3d0    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#516B6B      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#a5e3d0      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#a5e3d0  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#a5e3d0      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#a5e3d0    ctermbg=bg  ctermfg=152
+hi Character   guibg=bg    guifg=#516B6B      ctermbg=bg  ctermfg=59
+hi Number      guibg=bg    guifg=#a5e3d0      ctermbg=bg   ctermfg=152
+hi Boolean     guibg=bg    guifg=#a5e3d0  gui=none    ctermbg=bg   ctermfg=152
+hi Float       guibg=bg    guifg=#a5e3d0      ctermbg=bg   ctermfg=152
 
-hi Identifier  guibg=bg    guifg=#EDEBE6      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#516B6B      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#516B6B      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#EDEBE6      ctermbg=bg  ctermfg=230
+hi Function    guibg=bg    guifg=#516B6B      ctermbg=bg  ctermfg=59
+hi Statement   guibg=bg    guifg=#516B6B      ctermbg=bg  ctermfg=59
 
-hi Conditional guibg=bg    guifg=#A2A797      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#A2A797      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#A2A797      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#A2A797      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#516B6B      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#A2A797      ctermbg=bg  ctermfg=144
+hi Repeat      guibg=bg    guifg=#A2A797      ctermbg=bg   ctermfg=144
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#A2A797      ctermbg=bg   ctermfg=144
+hi Keyword     guibg=bg    guifg=#A2A797      ctermbg=bg  ctermfg=144
+hi Exception   guibg=bg    guifg=#516B6B      ctermbg=bg  ctermfg=59
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#A2A797   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#A2A797   ctermbg=bg ctermfg=144
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#A2A797      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#516B6B      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#EDEBE6      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#A2A797    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#A2A797      ctermbg=bg  ctermfg=144
+hi StorageClass   guibg=bg   guifg=#516B6B      ctermbg=bg  ctermfg=59
+hi Structure      guibg=bg   guifg=#EDEBE6      ctermbg=bg  ctermfg=230
+hi Typedef    guibg=bg   guifg=#A2A797    ctermbg=bg  ctermfg=144
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#605852    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#605852    ctermbg=59   ctermfg=59
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#EDEBE6        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#EDEBE6        ctermbg=bg   ctermfg=230
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/azure.vim
+++ b/vim/colors/azure.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#181D26  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#181D26  guifg=#ffffff    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#6AB0A3   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#6AB0A3   ctermbg=bg ctermfg=73
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#414d62  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#414d62  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#64aeb3    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#52708b      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#64aeb3      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#64aeb3  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#64aeb3      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#64aeb3    ctermbg=bg  ctermfg=73
+hi Character   guibg=bg    guifg=#52708b      ctermbg=bg  ctermfg=60
+hi Number      guibg=bg    guifg=#64aeb3      ctermbg=bg   ctermfg=73
+hi Boolean     guibg=bg    guifg=#64aeb3  gui=none    ctermbg=bg   ctermfg=73
+hi Float       guibg=bg    guifg=#64aeb3      ctermbg=bg   ctermfg=73
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#52708b      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#52708b      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#52708b      ctermbg=bg  ctermfg=60
+hi Statement   guibg=bg    guifg=#52708b      ctermbg=bg  ctermfg=60
 
-hi Conditional guibg=bg    guifg=#508aaa      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#508aaa      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#508aaa      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#508aaa      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#52708b      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#508aaa      ctermbg=bg  ctermfg=67
+hi Repeat      guibg=bg    guifg=#508aaa      ctermbg=bg   ctermfg=67
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#508aaa      ctermbg=bg   ctermfg=67
+hi Keyword     guibg=bg    guifg=#508aaa      ctermbg=bg  ctermfg=67
+hi Exception   guibg=bg    guifg=#52708b      ctermbg=bg  ctermfg=60
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#6AB0A3   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#6AB0A3   ctermbg=bg ctermfg=73
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#6AB0A3      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#52708b      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#6AB0A3    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#6AB0A3      ctermbg=bg  ctermfg=73
+hi StorageClass   guibg=bg   guifg=#52708b      ctermbg=bg  ctermfg=60
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#6AB0A3    ctermbg=bg  ctermfg=73
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#5c6b86    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#5c6b86    ctermbg=59   ctermfg=60
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/bold.vim
+++ b/vim/colors/bold.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2a2626  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2a2626  guifg=#ffffff    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#3D8E91   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#3D8E91   ctermbg=bg ctermfg=66
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#534b4b  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#534b4b  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F7A21B    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#F0624B      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F7A21B      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F7A21B  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F7A21B      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F7A21B    ctermbg=bg  ctermfg=214
+hi Character   guibg=bg    guifg=#F0624B      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#F7A21B      ctermbg=bg   ctermfg=214
+hi Boolean     guibg=bg    guifg=#F7A21B  gui=none    ctermbg=bg   ctermfg=214
+hi Float       guibg=bg    guifg=#F7A21B      ctermbg=bg   ctermfg=214
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#F0624B      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#F0624B      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#F0624B      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#F0624B      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#F0624B      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#F0624B      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#F0624B      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#F0624B      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#F0624B      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#F0624B      ctermbg=bg  ctermfg=203
+hi Repeat      guibg=bg    guifg=#F0624B      ctermbg=bg   ctermfg=203
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#F0624B      ctermbg=bg   ctermfg=203
+hi Keyword     guibg=bg    guifg=#F0624B      ctermbg=bg  ctermfg=203
+hi Exception   guibg=bg    guifg=#F0624B      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#3D8E91   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#3D8E91   ctermbg=bg ctermfg=66
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#3D8E91      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#F0624B      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#3D8E91    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#3D8E91      ctermbg=bg  ctermfg=66
+hi StorageClass   guibg=bg   guifg=#F0624B      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#3D8E91    ctermbg=bg  ctermfg=66
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#6b6161    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#6b6161    ctermbg=59   ctermfg=59
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/boxuk.vim
+++ b/vim/colors/boxuk.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#ffffff  guifg=#414f5c    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#414f5c   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#ffffff  guifg=#414f5c    gui=none ctermbg=231 ctermfg=59
+hi NonText     guibg=bg  guifg=#414f5c   ctermbg=bg ctermfg=59
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#017c9d   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#017c9d   ctermbg=bg ctermfg=31
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#b8b6b1  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#b8b6b1  gui=none    ctermbg=bg   ctermfg=145
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#15b8ae    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#019d76      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#15b8ae      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#15b8ae  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#15b8ae      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#15b8ae    ctermbg=bg  ctermfg=37
+hi Character   guibg=bg    guifg=#019d76      ctermbg=bg  ctermfg=36
+hi Number      guibg=bg    guifg=#15b8ae      ctermbg=bg   ctermfg=37
+hi Boolean     guibg=bg    guifg=#15b8ae  gui=none    ctermbg=bg   ctermfg=37
+hi Float       guibg=bg    guifg=#15b8ae      ctermbg=bg   ctermfg=37
 
-hi Identifier  guibg=bg    guifg=#414f5c      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#019d76      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#019d76      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#414f5c      ctermbg=bg  ctermfg=59
+hi Function    guibg=bg    guifg=#019d76      ctermbg=bg  ctermfg=36
+hi Statement   guibg=bg    guifg=#019d76      ctermbg=bg  ctermfg=36
 
-hi Conditional guibg=bg    guifg=#017c9d      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#017c9d      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#017c9d      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#017c9d      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#019d76      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#017c9d      ctermbg=bg  ctermfg=31
+hi Repeat      guibg=bg    guifg=#017c9d      ctermbg=bg   ctermfg=31
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#017c9d      ctermbg=bg   ctermfg=31
+hi Keyword     guibg=bg    guifg=#017c9d      ctermbg=bg  ctermfg=31
+hi Exception   guibg=bg    guifg=#019d76      ctermbg=bg  ctermfg=36
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#017c9d   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#017c9d   ctermbg=bg ctermfg=31
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#017c9d      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#019d76      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#414f5c      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#017c9d    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#017c9d      ctermbg=bg  ctermfg=31
+hi StorageClass   guibg=bg   guifg=#019d76      ctermbg=bg  ctermfg=36
+hi Structure      guibg=bg   guifg=#414f5c      ctermbg=bg  ctermfg=59
+hi Typedef    guibg=bg   guifg=#017c9d    ctermbg=bg  ctermfg=31
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#888888    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#888888    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#414f5c        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#414f5c        ctermbg=bg   ctermfg=59
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/carbonight-contrast.vim
+++ b/vim/colors/carbonight-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#000000  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#000000  guifg=#ffffff    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#C4C4C4   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#C4C4C4   ctermbg=bg ctermfg=188
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#423F3D  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#423F3D  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#ffffff    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#B0B0B0      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#B0B0B0  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#B0B0B0      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#ffffff    ctermbg=bg  ctermfg=231
+hi Character   guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=102
+hi Number      guibg=bg    guifg=#B0B0B0      ctermbg=bg   ctermfg=145
+hi Boolean     guibg=bg    guifg=#B0B0B0  gui=none    ctermbg=bg   ctermfg=145
+hi Float       guibg=bg    guifg=#B0B0B0      ctermbg=bg   ctermfg=145
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=102
+hi Statement   guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=102
 
-hi Conditional guibg=bg    guifg=#eeeeee      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#eeeeee      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#eeeeee      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#eeeeee      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#eeeeee      ctermbg=bg  ctermfg=231
+hi Repeat      guibg=bg    guifg=#eeeeee      ctermbg=bg   ctermfg=231
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#eeeeee      ctermbg=bg   ctermfg=231
+hi Keyword     guibg=bg    guifg=#eeeeee      ctermbg=bg  ctermfg=231
+hi Exception   guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=102
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#C4C4C4   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#C4C4C4   ctermbg=bg ctermfg=188
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#C4C4C4      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#8C8C8C      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#C4C4C4    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#C4C4C4      ctermbg=bg  ctermfg=188
+hi StorageClass   guibg=bg   guifg=#8C8C8C      ctermbg=bg  ctermfg=102
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#C4C4C4    ctermbg=bg  ctermfg=188
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#5c5856    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#5c5856    ctermbg=59   ctermfg=59
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/carbonight.vim
+++ b/vim/colors/carbonight.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2E2C2B  guifg=#B0B0B0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#B0B0B0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2E2C2B  guifg=#B0B0B0    gui=none ctermbg=16 ctermfg=145
+hi NonText     guibg=bg  guifg=#B0B0B0   ctermbg=bg ctermfg=145
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#C4C4C4   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#C4C4C4   ctermbg=bg ctermfg=188
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#423F3D  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#423F3D  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#ffffff    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#B0B0B0      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#B0B0B0  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#B0B0B0      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#ffffff    ctermbg=bg  ctermfg=231
+hi Character   guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=102
+hi Number      guibg=bg    guifg=#B0B0B0      ctermbg=bg   ctermfg=145
+hi Boolean     guibg=bg    guifg=#B0B0B0  gui=none    ctermbg=bg   ctermfg=145
+hi Float       guibg=bg    guifg=#B0B0B0      ctermbg=bg   ctermfg=145
 
-hi Identifier  guibg=bg    guifg=#B0B0B0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#B0B0B0      ctermbg=bg  ctermfg=145
+hi Function    guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=102
+hi Statement   guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=102
 
-hi Conditional guibg=bg    guifg=#eeeeee      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#eeeeee      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#eeeeee      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#eeeeee      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#eeeeee      ctermbg=bg  ctermfg=231
+hi Repeat      guibg=bg    guifg=#eeeeee      ctermbg=bg   ctermfg=231
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#eeeeee      ctermbg=bg   ctermfg=231
+hi Keyword     guibg=bg    guifg=#eeeeee      ctermbg=bg  ctermfg=231
+hi Exception   guibg=bg    guifg=#8C8C8C      ctermbg=bg  ctermfg=102
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#C4C4C4   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#C4C4C4   ctermbg=bg ctermfg=188
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#C4C4C4      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#8C8C8C      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#B0B0B0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#C4C4C4    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#C4C4C4      ctermbg=bg  ctermfg=188
+hi StorageClass   guibg=bg   guifg=#8C8C8C      ctermbg=bg  ctermfg=102
+hi Structure      guibg=bg   guifg=#B0B0B0      ctermbg=bg  ctermfg=145
+hi Typedef    guibg=bg   guifg=#C4C4C4    ctermbg=bg  ctermfg=188
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#5c5856    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#5c5856    ctermbg=59   ctermfg=59
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#B0B0B0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#B0B0B0        ctermbg=bg   ctermfg=145
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/chocolate.vim
+++ b/vim/colors/chocolate.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#150f08  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#150f08  guifg=#ffffff    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#8B6E46   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#8B6E46   ctermbg=bg ctermfg=95
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#795431  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#795431  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F7A21B    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#CCB697      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F7A21B      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F7A21B  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F7A21B      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F7A21B    ctermbg=bg  ctermfg=214
+hi Character   guibg=bg    guifg=#CCB697      ctermbg=bg  ctermfg=180
+hi Number      guibg=bg    guifg=#F7A21B      ctermbg=bg   ctermfg=214
+hi Boolean     guibg=bg    guifg=#F7A21B  gui=none    ctermbg=bg   ctermfg=214
+hi Float       guibg=bg    guifg=#F7A21B      ctermbg=bg   ctermfg=214
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#CCB697      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#CCB697      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#CCB697      ctermbg=bg  ctermfg=180
+hi Statement   guibg=bg    guifg=#CCB697      ctermbg=bg  ctermfg=180
 
-hi Conditional guibg=bg    guifg=#B99768      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#B99768      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#B99768      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#B99768      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#CCB697      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#B99768      ctermbg=bg  ctermfg=137
+hi Repeat      guibg=bg    guifg=#B99768      ctermbg=bg   ctermfg=137
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#B99768      ctermbg=bg   ctermfg=137
+hi Keyword     guibg=bg    guifg=#B99768      ctermbg=bg  ctermfg=137
+hi Exception   guibg=bg    guifg=#CCB697      ctermbg=bg  ctermfg=180
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#8B6E46   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#8B6E46   ctermbg=bg ctermfg=95
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#8B6E46      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#CCB697      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#8B6E46    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#8B6E46      ctermbg=bg  ctermfg=95
+hi StorageClass   guibg=bg   guifg=#CCB697      ctermbg=bg  ctermfg=180
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#8B6E46    ctermbg=bg  ctermfg=95
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#795431    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#795431    ctermbg=59   ctermfg=95
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/crisp.vim
+++ b/vim/colors/crisp.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#221a22  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#221a22  guifg=#ffffff    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#cba0cd   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#cba0cd   ctermbg=bg ctermfg=182
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#574457  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#574457  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#fc9a0f    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#765478      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#fc9a0f      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#fc9a0f  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#fc9a0f      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#fc9a0f    ctermbg=bg  ctermfg=208
+hi Character   guibg=bg    guifg=#765478      ctermbg=bg  ctermfg=96
+hi Number      guibg=bg    guifg=#fc9a0f      ctermbg=bg   ctermfg=208
+hi Boolean     guibg=bg    guifg=#fc9a0f  gui=none    ctermbg=bg   ctermfg=208
+hi Float       guibg=bg    guifg=#fc9a0f      ctermbg=bg   ctermfg=208
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#765478      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#765478      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#765478      ctermbg=bg  ctermfg=96
+hi Statement   guibg=bg    guifg=#765478      ctermbg=bg  ctermfg=96
 
-hi Conditional guibg=bg    guifg=#FC6A0F      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#FC6A0F      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#FC6A0F      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#FC6A0F      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#765478      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#FC6A0F      ctermbg=bg  ctermfg=202
+hi Repeat      guibg=bg    guifg=#FC6A0F      ctermbg=bg   ctermfg=202
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#FC6A0F      ctermbg=bg   ctermfg=202
+hi Keyword     guibg=bg    guifg=#FC6A0F      ctermbg=bg  ctermfg=202
+hi Exception   guibg=bg    guifg=#765478      ctermbg=bg  ctermfg=96
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#cba0cd   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#cba0cd   ctermbg=bg ctermfg=182
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#cba0cd      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#765478      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#cba0cd    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#cba0cd      ctermbg=bg  ctermfg=182
+hi StorageClass   guibg=bg   guifg=#765478      ctermbg=bg  ctermfg=96
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#cba0cd    ctermbg=bg  ctermfg=182
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#776377    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#776377    ctermbg=59   ctermfg=96
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/darkside-contrast.vim
+++ b/vim/colors/darkside-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#000000  guifg=#BABABA    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#BABABA   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#000000  guifg=#BABABA    gui=none ctermbg=16 ctermfg=145
+hi NonText     guibg=bg  guifg=#BABABA   ctermbg=bg ctermfg=145
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#1CC3E8   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#1CC3E8   ctermbg=bg ctermfg=44
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#494B4D  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#494B4D  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F2D42C    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#8E69C9      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#8E69C9  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#8E69C9      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F2D42C    ctermbg=bg  ctermfg=220
+hi Character   guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=166
+hi Number      guibg=bg    guifg=#8E69C9      ctermbg=bg   ctermfg=98
+hi Boolean     guibg=bg    guifg=#8E69C9  gui=none    ctermbg=bg   ctermfg=98
+hi Float       guibg=bg    guifg=#8E69C9      ctermbg=bg   ctermfg=98
 
-hi Identifier  guibg=bg    guifg=#BABABA      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#BABABA      ctermbg=bg  ctermfg=145
+hi Function    guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=166
+hi Statement   guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=166
 
-hi Conditional guibg=bg    guifg=#F08D24      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#F08D24      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#F08D24      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#F08D24      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#F08D24      ctermbg=bg  ctermfg=208
+hi Repeat      guibg=bg    guifg=#F08D24      ctermbg=bg   ctermfg=208
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#F08D24      ctermbg=bg   ctermfg=208
+hi Keyword     guibg=bg    guifg=#F08D24      ctermbg=bg  ctermfg=208
+hi Exception   guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=166
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#1CC3E8   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#1CC3E8   ctermbg=bg ctermfg=44
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#1CC3E8      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#E8341C      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#BABABA      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#1CC3E8    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#1CC3E8      ctermbg=bg  ctermfg=44
+hi StorageClass   guibg=bg   guifg=#E8341C      ctermbg=bg  ctermfg=166
+hi Structure      guibg=bg   guifg=#BABABA      ctermbg=bg  ctermfg=145
+hi Typedef    guibg=bg   guifg=#1CC3E8    ctermbg=bg  ctermfg=44
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#696b6e    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#696b6e    ctermbg=59   ctermfg=59
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#BABABA        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#BABABA        ctermbg=bg   ctermfg=145
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/darkside.vim
+++ b/vim/colors/darkside.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#222324  guifg=#BABABA    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#BABABA   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#222324  guifg=#BABABA    gui=none ctermbg=16 ctermfg=145
+hi NonText     guibg=bg  guifg=#BABABA   ctermbg=bg ctermfg=145
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#1CC3E8   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#1CC3E8   ctermbg=bg ctermfg=44
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#494B4D  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#494B4D  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F2D42C    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#8E69C9      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#8E69C9  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#8E69C9      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F2D42C    ctermbg=bg  ctermfg=220
+hi Character   guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=166
+hi Number      guibg=bg    guifg=#8E69C9      ctermbg=bg   ctermfg=98
+hi Boolean     guibg=bg    guifg=#8E69C9  gui=none    ctermbg=bg   ctermfg=98
+hi Float       guibg=bg    guifg=#8E69C9      ctermbg=bg   ctermfg=98
 
-hi Identifier  guibg=bg    guifg=#BABABA      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#BABABA      ctermbg=bg  ctermfg=145
+hi Function    guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=166
+hi Statement   guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=166
 
-hi Conditional guibg=bg    guifg=#F08D24      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#F08D24      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#F08D24      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#F08D24      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#F08D24      ctermbg=bg  ctermfg=208
+hi Repeat      guibg=bg    guifg=#F08D24      ctermbg=bg   ctermfg=208
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#F08D24      ctermbg=bg   ctermfg=208
+hi Keyword     guibg=bg    guifg=#F08D24      ctermbg=bg  ctermfg=208
+hi Exception   guibg=bg    guifg=#E8341C      ctermbg=bg  ctermfg=166
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#1CC3E8   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#1CC3E8   ctermbg=bg ctermfg=44
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#1CC3E8      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#E8341C      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#BABABA      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#1CC3E8    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#1CC3E8      ctermbg=bg  ctermfg=44
+hi StorageClass   guibg=bg   guifg=#E8341C      ctermbg=bg  ctermfg=166
+hi Structure      guibg=bg   guifg=#BABABA      ctermbg=bg  ctermfg=145
+hi Typedef    guibg=bg   guifg=#1CC3E8    ctermbg=bg  ctermfg=44
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#696b6e    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#696b6e    ctermbg=59   ctermfg=59
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#BABABA        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#BABABA        ctermbg=bg   ctermfg=145
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/earthsong-contrast.vim
+++ b/vim/colors/earthsong-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#12100f  guifg=#EBD1B7    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#EBD1B7   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#12100f  guifg=#EBD1B7    gui=none ctermbg=16 ctermfg=223
+hi NonText     guibg=bg  guifg=#EBD1B7   ctermbg=bg ctermfg=223
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#95CC5E   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#95CC5E   ctermbg=bg ctermfg=113
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F8BB39      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F8BB39  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F8BB39      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=215
+hi Character   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Number      guibg=bg    guifg=#F8BB39      ctermbg=bg   ctermfg=215
+hi Boolean     guibg=bg    guifg=#F8BB39  gui=none    ctermbg=bg   ctermfg=215
+hi Float       guibg=bg    guifg=#F8BB39      ctermbg=bg   ctermfg=215
 
-hi Identifier  guibg=bg    guifg=#EBD1B7      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#EBD1B7      ctermbg=bg  ctermfg=223
+hi Function    guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Statement   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
 
-hi Conditional guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#DB784D      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#DB784D      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Repeat      guibg=bg    guifg=#DB784D      ctermbg=bg   ctermfg=173
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#DB784D      ctermbg=bg   ctermfg=173
+hi Keyword     guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Exception   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#95CC5E   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#95CC5E   ctermbg=bg ctermfg=113
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#95CC5E      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#DB784D      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#EBD1B7      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#95CC5E    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#95CC5E      ctermbg=bg  ctermfg=113
+hi StorageClass   guibg=bg   guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Structure      guibg=bg   guifg=#EBD1B7      ctermbg=bg  ctermfg=223
+hi Typedef    guibg=bg   guifg=#95CC5E    ctermbg=bg  ctermfg=113
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#9a9082    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#9a9082    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#EBD1B7        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#EBD1B7        ctermbg=bg   ctermfg=223
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/earthsong-light.vim
+++ b/vim/colors/earthsong-light.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#ffffff  guifg=#4d463e    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#4d463e   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#ffffff  guifg=#4d463e    gui=none ctermbg=231 ctermfg=59
+hi NonText     guibg=bg  guifg=#4d463e   ctermbg=bg ctermfg=59
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#95CC5E   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#95CC5E   ctermbg=bg ctermfg=113
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#d6cab9  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#d6cab9  gui=none    ctermbg=bg   ctermfg=187
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F8BB39      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F8BB39  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F8BB39      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=215
+hi Character   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Number      guibg=bg    guifg=#F8BB39      ctermbg=bg   ctermfg=215
+hi Boolean     guibg=bg    guifg=#F8BB39  gui=none    ctermbg=bg   ctermfg=215
+hi Float       guibg=bg    guifg=#F8BB39      ctermbg=bg   ctermfg=215
 
-hi Identifier  guibg=bg    guifg=#4d463e      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#4d463e      ctermbg=bg  ctermfg=59
+hi Function    guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Statement   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
 
-hi Conditional guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#DB784D      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#DB784D      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Repeat      guibg=bg    guifg=#DB784D      ctermbg=bg   ctermfg=173
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#DB784D      ctermbg=bg   ctermfg=173
+hi Keyword     guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Exception   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#95CC5E   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#95CC5E   ctermbg=bg ctermfg=113
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#95CC5E      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#DB784D      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#4d463e      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#95CC5E    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#95CC5E      ctermbg=bg  ctermfg=113
+hi StorageClass   guibg=bg   guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Structure      guibg=bg   guifg=#4d463e      ctermbg=bg  ctermfg=59
+hi Typedef    guibg=bg   guifg=#95CC5E    ctermbg=bg  ctermfg=113
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#9a9082    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#9a9082    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#4d463e        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#4d463e        ctermbg=bg   ctermfg=59
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/earthsong.vim
+++ b/vim/colors/earthsong.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#36312C  guifg=#EBD1B7    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#EBD1B7   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#36312C  guifg=#EBD1B7    gui=none ctermbg=58 ctermfg=223
+hi NonText     guibg=bg  guifg=#EBD1B7   ctermbg=bg ctermfg=223
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#95CC5E   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#95CC5E   ctermbg=bg ctermfg=113
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F8BB39      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F8BB39  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F8BB39      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=215
+hi Character   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Number      guibg=bg    guifg=#F8BB39      ctermbg=bg   ctermfg=215
+hi Boolean     guibg=bg    guifg=#F8BB39  gui=none    ctermbg=bg   ctermfg=215
+hi Float       guibg=bg    guifg=#F8BB39      ctermbg=bg   ctermfg=215
 
-hi Identifier  guibg=bg    guifg=#EBD1B7      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#EBD1B7      ctermbg=bg  ctermfg=223
+hi Function    guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Statement   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
 
-hi Conditional guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#DB784D      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#DB784D      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Repeat      guibg=bg    guifg=#DB784D      ctermbg=bg   ctermfg=173
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#DB784D      ctermbg=bg   ctermfg=173
+hi Keyword     guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Exception   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#95CC5E   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#95CC5E   ctermbg=bg ctermfg=113
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#95CC5E      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#DB784D      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#EBD1B7      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#95CC5E    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#95CC5E      ctermbg=bg  ctermfg=113
+hi StorageClass   guibg=bg   guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Structure      guibg=bg   guifg=#EBD1B7      ctermbg=bg  ctermfg=223
+hi Typedef    guibg=bg   guifg=#95CC5E    ctermbg=bg  ctermfg=113
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#9a9082    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#9a9082    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#EBD1B7        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#EBD1B7        ctermbg=bg   ctermfg=223
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/freshcut-contrast.vim
+++ b/vim/colors/freshcut-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#000000  guifg=#F8F8F2    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#000000  guifg=#F8F8F2    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#4ECDC4   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#4ECDC4   ctermbg=bg ctermfg=80
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#737b84  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#737b84  gui=none    ctermbg=bg   ctermfg=102
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#e9ee00    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#8FBE00      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#8FBE00  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#8FBE00      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#e9ee00    ctermbg=bg  ctermfg=190
+hi Character   guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=38
+hi Number      guibg=bg    guifg=#8FBE00      ctermbg=bg   ctermfg=106
+hi Boolean     guibg=bg    guifg=#8FBE00  gui=none    ctermbg=bg   ctermfg=106
+hi Float       guibg=bg    guifg=#8FBE00      ctermbg=bg   ctermfg=106
 
-hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=38
+hi Statement   guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=38
 
-hi Conditional guibg=bg    guifg=#C8D7E8      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#C8D7E8      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#C8D7E8      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#C8D7E8      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#C8D7E8      ctermbg=bg  ctermfg=188
+hi Repeat      guibg=bg    guifg=#C8D7E8      ctermbg=bg   ctermfg=188
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#C8D7E8      ctermbg=bg   ctermfg=188
+hi Keyword     guibg=bg    guifg=#C8D7E8      ctermbg=bg  ctermfg=188
+hi Exception   guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=38
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#4ECDC4   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#4ECDC4   ctermbg=bg ctermfg=80
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#4ECDC4      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#00A8C6      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#4ECDC4    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#4ECDC4      ctermbg=bg  ctermfg=80
+hi StorageClass   guibg=bg   guifg=#00A8C6      ctermbg=bg  ctermfg=38
+hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#4ECDC4    ctermbg=bg  ctermfg=80
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#939da8    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#939da8    ctermbg=59   ctermfg=109
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/freshcut.vim
+++ b/vim/colors/freshcut.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2F3030  guifg=#F8F8F2    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2F3030  guifg=#F8F8F2    gui=none ctermbg=23 ctermfg=231
+hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#4ECDC4   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#4ECDC4   ctermbg=bg ctermfg=80
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#737b84  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#737b84  gui=none    ctermbg=bg   ctermfg=102
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#e9ee00    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#8FBE00      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#8FBE00  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#8FBE00      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#e9ee00    ctermbg=bg  ctermfg=190
+hi Character   guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=38
+hi Number      guibg=bg    guifg=#8FBE00      ctermbg=bg   ctermfg=106
+hi Boolean     guibg=bg    guifg=#8FBE00  gui=none    ctermbg=bg   ctermfg=106
+hi Float       guibg=bg    guifg=#8FBE00      ctermbg=bg   ctermfg=106
 
-hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=38
+hi Statement   guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=38
 
-hi Conditional guibg=bg    guifg=#C8D7E8      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#C8D7E8      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#C8D7E8      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#C8D7E8      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#C8D7E8      ctermbg=bg  ctermfg=188
+hi Repeat      guibg=bg    guifg=#C8D7E8      ctermbg=bg   ctermfg=188
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#C8D7E8      ctermbg=bg   ctermfg=188
+hi Keyword     guibg=bg    guifg=#C8D7E8      ctermbg=bg  ctermfg=188
+hi Exception   guibg=bg    guifg=#00A8C6      ctermbg=bg  ctermfg=38
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#4ECDC4   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#4ECDC4   ctermbg=bg ctermfg=80
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#4ECDC4      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#00A8C6      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#4ECDC4    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#4ECDC4      ctermbg=bg  ctermfg=80
+hi StorageClass   guibg=bg   guifg=#00A8C6      ctermbg=bg  ctermfg=38
+hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#4ECDC4    ctermbg=bg  ctermfg=80
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#939da8    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#939da8    ctermbg=59   ctermfg=109
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/frontier-contrast.vim
+++ b/vim/colors/frontier-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#110f0e  guifg=#F8F8F2    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#110f0e  guifg=#F8F8F2    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#2EBF7E   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#2EBF7E   ctermbg=bg ctermfg=36
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#2EBF7E      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#2EBF7E  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#2EBF7E      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=215
+hi Character   guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#2EBF7E      ctermbg=bg   ctermfg=36
+hi Boolean     guibg=bg    guifg=#2EBF7E  gui=none    ctermbg=bg   ctermfg=36
+hi Float       guibg=bg    guifg=#2EBF7E      ctermbg=bg   ctermfg=36
 
-hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#FC803D      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#FC803D      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#FC803D      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#FC803D      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#FC803D      ctermbg=bg  ctermfg=209
+hi Repeat      guibg=bg    guifg=#FC803D      ctermbg=bg   ctermfg=209
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#FC803D      ctermbg=bg   ctermfg=209
+hi Keyword     guibg=bg    guifg=#FC803D      ctermbg=bg  ctermfg=209
+hi Exception   guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#2EBF7E   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#2EBF7E   ctermbg=bg ctermfg=36
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#2EBF7E      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#F23A3A      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#2EBF7E    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#2EBF7E      ctermbg=bg  ctermfg=36
+hi StorageClass   guibg=bg   guifg=#F23A3A      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#2EBF7E    ctermbg=bg  ctermfg=36
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#a59a8a    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#a59a8a    ctermbg=59   ctermfg=138
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/frontier.vim
+++ b/vim/colors/frontier.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#36312C  guifg=#F8F8F2    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#36312C  guifg=#F8F8F2    gui=none ctermbg=58 ctermfg=231
+hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#2EBF7E   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#2EBF7E   ctermbg=bg ctermfg=36
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#2EBF7E      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#2EBF7E  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#2EBF7E      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=215
+hi Character   guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#2EBF7E      ctermbg=bg   ctermfg=36
+hi Boolean     guibg=bg    guifg=#2EBF7E  gui=none    ctermbg=bg   ctermfg=36
+hi Float       guibg=bg    guifg=#2EBF7E      ctermbg=bg   ctermfg=36
 
-hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#FC803D      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#FC803D      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#FC803D      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#FC803D      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#FC803D      ctermbg=bg  ctermfg=209
+hi Repeat      guibg=bg    guifg=#FC803D      ctermbg=bg   ctermfg=209
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#FC803D      ctermbg=bg   ctermfg=209
+hi Keyword     guibg=bg    guifg=#FC803D      ctermbg=bg  ctermfg=209
+hi Exception   guibg=bg    guifg=#F23A3A      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#2EBF7E   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#2EBF7E   ctermbg=bg ctermfg=36
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#2EBF7E      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#F23A3A      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#2EBF7E    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#2EBF7E      ctermbg=bg  ctermfg=36
+hi StorageClass   guibg=bg   guifg=#F23A3A      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#2EBF7E    ctermbg=bg  ctermfg=36
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#a59a8a    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#a59a8a    ctermbg=59   ctermfg=138
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/github.vim
+++ b/vim/colors/github.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#ffffff  guifg=#555555    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#555555   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#ffffff  guifg=#555555    gui=none ctermbg=231 ctermfg=59
+hi NonText     guibg=bg  guifg=#555555   ctermbg=bg ctermfg=59
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#445588   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#445588   ctermbg=bg ctermfg=60
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#b8b6b1  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#b8b6b1  gui=none    ctermbg=bg   ctermfg=145
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#DD1144    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#008080      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#DD1144      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#DD1144  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#DD1144      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#DD1144    ctermbg=bg  ctermfg=161
+hi Character   guibg=bg    guifg=#008080      ctermbg=bg  ctermfg=30
+hi Number      guibg=bg    guifg=#DD1144      ctermbg=bg   ctermfg=161
+hi Boolean     guibg=bg    guifg=#DD1144  gui=none    ctermbg=bg   ctermfg=161
+hi Float       guibg=bg    guifg=#DD1144      ctermbg=bg   ctermfg=161
 
-hi Identifier  guibg=bg    guifg=#555555      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#008080      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#008080      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#555555      ctermbg=bg  ctermfg=59
+hi Function    guibg=bg    guifg=#008080      ctermbg=bg  ctermfg=30
+hi Statement   guibg=bg    guifg=#008080      ctermbg=bg  ctermfg=30
 
-hi Conditional guibg=bg    guifg=#555555      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#555555      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#555555      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#555555      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#008080      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#555555      ctermbg=bg  ctermfg=59
+hi Repeat      guibg=bg    guifg=#555555      ctermbg=bg   ctermfg=59
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#555555      ctermbg=bg   ctermfg=59
+hi Keyword     guibg=bg    guifg=#555555      ctermbg=bg  ctermfg=59
+hi Exception   guibg=bg    guifg=#008080      ctermbg=bg  ctermfg=30
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#445588   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#445588   ctermbg=bg ctermfg=60
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#445588      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#008080      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#555555      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#445588    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#445588      ctermbg=bg  ctermfg=60
+hi StorageClass   guibg=bg   guifg=#008080      ctermbg=bg  ctermfg=30
+hi Structure      guibg=bg   guifg=#555555      ctermbg=bg  ctermfg=59
+hi Typedef    guibg=bg   guifg=#445588    ctermbg=bg  ctermfg=60
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#7f7e7a    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#7f7e7a    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#555555        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#555555        ctermbg=bg   ctermfg=59
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/gloom-contrast.vim
+++ b/vim/colors/gloom-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0f120f  guifg=#D8EBE5    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#D8EBE5   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0f120f  guifg=#D8EBE5    gui=none ctermbg=16 ctermfg=194
+hi NonText     guibg=bg  guifg=#D8EBE5   ctermbg=bg ctermfg=194
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#26A6A6   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#26A6A6   ctermbg=bg ctermfg=37
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#4F6E64  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#4F6E64  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#BCD42A    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#BCD42A      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#BCD42A  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#BCD42A      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#BCD42A    ctermbg=bg  ctermfg=148
+hi Character   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#BCD42A      ctermbg=bg   ctermfg=148
+hi Boolean     guibg=bg    guifg=#BCD42A  gui=none    ctermbg=bg   ctermfg=148
+hi Float       guibg=bg    guifg=#BCD42A      ctermbg=bg   ctermfg=148
 
-hi Identifier  guibg=bg    guifg=#D8EBE5      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#D8EBE5      ctermbg=bg  ctermfg=194
+hi Function    guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#26A6A6      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#26A6A6      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi Repeat      guibg=bg    guifg=#26A6A6      ctermbg=bg   ctermfg=37
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#26A6A6      ctermbg=bg   ctermfg=37
+hi Keyword     guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi Exception   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#26A6A6   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#26A6A6   ctermbg=bg ctermfg=37
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#26A6A6      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#FF5D38      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#D8EBE5      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#26A6A6    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi StorageClass   guibg=bg   guifg=#FF5D38      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#D8EBE5      ctermbg=bg  ctermfg=194
+hi Typedef    guibg=bg   guifg=#26A6A6    ctermbg=bg  ctermfg=37
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#668e81    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#668e81    ctermbg=59   ctermfg=66
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#D8EBE5        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#D8EBE5        ctermbg=bg   ctermfg=194
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/gloom.vim
+++ b/vim/colors/gloom.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2A332B  guifg=#D8EBE5    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#D8EBE5   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2A332B  guifg=#D8EBE5    gui=none ctermbg=22 ctermfg=194
+hi NonText     guibg=bg  guifg=#D8EBE5   ctermbg=bg ctermfg=194
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#26A6A6   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#26A6A6   ctermbg=bg ctermfg=37
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#4F6E64  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#4F6E64  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#BCD42A    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#BCD42A      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#BCD42A  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#BCD42A      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#BCD42A    ctermbg=bg  ctermfg=148
+hi Character   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#BCD42A      ctermbg=bg   ctermfg=148
+hi Boolean     guibg=bg    guifg=#BCD42A  gui=none    ctermbg=bg   ctermfg=148
+hi Float       guibg=bg    guifg=#BCD42A      ctermbg=bg   ctermfg=148
 
-hi Identifier  guibg=bg    guifg=#D8EBE5      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#D8EBE5      ctermbg=bg  ctermfg=194
+hi Function    guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#26A6A6      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#26A6A6      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi Repeat      guibg=bg    guifg=#26A6A6      ctermbg=bg   ctermfg=37
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#26A6A6      ctermbg=bg   ctermfg=37
+hi Keyword     guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi Exception   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#26A6A6   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#26A6A6   ctermbg=bg ctermfg=37
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#26A6A6      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#FF5D38      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#D8EBE5      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#26A6A6    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi StorageClass   guibg=bg   guifg=#FF5D38      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#D8EBE5      ctermbg=bg  ctermfg=194
+hi Typedef    guibg=bg   guifg=#26A6A6    ctermbg=bg  ctermfg=37
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#668e81    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#668e81    ctermbg=59   ctermfg=66
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#D8EBE5        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#D8EBE5        ctermbg=bg   ctermfg=194
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/glowfish-contrast.vim
+++ b/vim/colors/glowfish-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#090b07  guifg=#6ea240    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#6ea240   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#090b07  guifg=#6ea240    gui=none ctermbg=16 ctermfg=71
+hi NonText     guibg=bg  guifg=#6ea240   ctermbg=bg ctermfg=71
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#95CC5E   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#95CC5E   ctermbg=bg ctermfg=113
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#3c4e2d  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#3c4e2d  gui=none    ctermbg=bg   ctermfg=58
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#95CC5E      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#95CC5E  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#95CC5E      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=215
+hi Character   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Number      guibg=bg    guifg=#95CC5E      ctermbg=bg   ctermfg=113
+hi Boolean     guibg=bg    guifg=#95CC5E  gui=none    ctermbg=bg   ctermfg=113
+hi Float       guibg=bg    guifg=#95CC5E      ctermbg=bg   ctermfg=113
 
-hi Identifier  guibg=bg    guifg=#6ea240      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#6ea240      ctermbg=bg  ctermfg=71
+hi Function    guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Statement   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
 
-hi Conditional guibg=bg    guifg=#D65940      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#D65940      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#D65940      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#D65940      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#D65940      ctermbg=bg  ctermfg=167
+hi Repeat      guibg=bg    guifg=#D65940      ctermbg=bg   ctermfg=167
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#D65940      ctermbg=bg   ctermfg=167
+hi Keyword     guibg=bg    guifg=#D65940      ctermbg=bg  ctermfg=167
+hi Exception   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#95CC5E   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#95CC5E   ctermbg=bg ctermfg=113
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#95CC5E      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#DB784D      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#6ea240      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#95CC5E    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#95CC5E      ctermbg=bg  ctermfg=113
+hi StorageClass   guibg=bg   guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Structure      guibg=bg   guifg=#6ea240      ctermbg=bg  ctermfg=71
+hi Typedef    guibg=bg   guifg=#95CC5E    ctermbg=bg  ctermfg=113
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#67854f    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#67854f    ctermbg=59   ctermfg=65
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#6ea240        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#6ea240        ctermbg=bg   ctermfg=71
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/glowfish.vim
+++ b/vim/colors/glowfish.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#191f13  guifg=#6ea240    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#6ea240   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#191f13  guifg=#6ea240    gui=none ctermbg=16 ctermfg=71
+hi NonText     guibg=bg  guifg=#6ea240   ctermbg=bg ctermfg=71
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#95CC5E   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#95CC5E   ctermbg=bg ctermfg=113
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#3c4e2d  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#3c4e2d  gui=none    ctermbg=bg   ctermfg=58
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#95CC5E      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#95CC5E  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#95CC5E      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=215
+hi Character   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Number      guibg=bg    guifg=#95CC5E      ctermbg=bg   ctermfg=113
+hi Boolean     guibg=bg    guifg=#95CC5E  gui=none    ctermbg=bg   ctermfg=113
+hi Float       guibg=bg    guifg=#95CC5E      ctermbg=bg   ctermfg=113
 
-hi Identifier  guibg=bg    guifg=#6ea240      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#6ea240      ctermbg=bg  ctermfg=71
+hi Function    guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Statement   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
 
-hi Conditional guibg=bg    guifg=#D65940      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#D65940      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#D65940      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#D65940      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#D65940      ctermbg=bg  ctermfg=167
+hi Repeat      guibg=bg    guifg=#D65940      ctermbg=bg   ctermfg=167
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#D65940      ctermbg=bg   ctermfg=167
+hi Keyword     guibg=bg    guifg=#D65940      ctermbg=bg  ctermfg=167
+hi Exception   guibg=bg    guifg=#DB784D      ctermbg=bg  ctermfg=173
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#95CC5E   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#95CC5E   ctermbg=bg ctermfg=113
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#95CC5E      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#DB784D      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#6ea240      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#95CC5E    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#95CC5E      ctermbg=bg  ctermfg=113
+hi StorageClass   guibg=bg   guifg=#DB784D      ctermbg=bg  ctermfg=173
+hi Structure      guibg=bg   guifg=#6ea240      ctermbg=bg  ctermfg=71
+hi Typedef    guibg=bg   guifg=#95CC5E    ctermbg=bg  ctermfg=113
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#67854f    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#67854f    ctermbg=59   ctermfg=65
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#6ea240        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#6ea240        ctermbg=bg   ctermfg=71
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/goldfish-contrast.vim
+++ b/vim/colors/goldfish-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0c0d0e  guifg=#F8F8F2    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0c0d0e  guifg=#F8F8F2    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#F38630   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#F38630   ctermbg=bg ctermfg=209
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#505C63  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#505C63  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#f36e3a    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#f25619      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#f25619  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#f25619      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#f36e3a    ctermbg=bg  ctermfg=203
+hi Character   guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=202
+hi Number      guibg=bg    guifg=#f25619      ctermbg=bg   ctermfg=202
+hi Boolean     guibg=bg    guifg=#f25619  gui=none    ctermbg=bg   ctermfg=202
+hi Float       guibg=bg    guifg=#f25619      ctermbg=bg   ctermfg=202
 
-hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=202
+hi Statement   guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=202
 
-hi Conditional guibg=bg    guifg=#A7DBD8      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#A7DBD8      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#A7DBD8      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#A7DBD8      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#A7DBD8      ctermbg=bg  ctermfg=152
+hi Repeat      guibg=bg    guifg=#A7DBD8      ctermbg=bg   ctermfg=152
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#A7DBD8      ctermbg=bg   ctermfg=152
+hi Keyword     guibg=bg    guifg=#A7DBD8      ctermbg=bg  ctermfg=152
+hi Exception   guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=202
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#F38630   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#F38630   ctermbg=bg ctermfg=209
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#F38630      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#FA6900      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#F38630    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#F38630      ctermbg=bg  ctermfg=209
+hi StorageClass   guibg=bg   guifg=#FA6900      ctermbg=bg  ctermfg=202
+hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#F38630    ctermbg=bg  ctermfg=209
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#798891    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#798891    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/goldfish.vim
+++ b/vim/colors/goldfish.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2E3336  guifg=#F8F8F2    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2E3336  guifg=#F8F8F2    gui=none ctermbg=23 ctermfg=231
+hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#F38630   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#F38630   ctermbg=bg ctermfg=209
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#505C63  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#505C63  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#f36e3a    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#f25619      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#f25619  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#f25619      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#f36e3a    ctermbg=bg  ctermfg=203
+hi Character   guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=202
+hi Number      guibg=bg    guifg=#f25619      ctermbg=bg   ctermfg=202
+hi Boolean     guibg=bg    guifg=#f25619  gui=none    ctermbg=bg   ctermfg=202
+hi Float       guibg=bg    guifg=#f25619      ctermbg=bg   ctermfg=202
 
-hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=202
+hi Statement   guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=202
 
-hi Conditional guibg=bg    guifg=#A7DBD8      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#A7DBD8      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#A7DBD8      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#A7DBD8      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#A7DBD8      ctermbg=bg  ctermfg=152
+hi Repeat      guibg=bg    guifg=#A7DBD8      ctermbg=bg   ctermfg=152
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#A7DBD8      ctermbg=bg   ctermfg=152
+hi Keyword     guibg=bg    guifg=#A7DBD8      ctermbg=bg  ctermfg=152
+hi Exception   guibg=bg    guifg=#FA6900      ctermbg=bg  ctermfg=202
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#F38630   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#F38630   ctermbg=bg ctermfg=209
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#F38630      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#FA6900      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#F38630    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#F38630      ctermbg=bg  ctermfg=209
+hi StorageClass   guibg=bg   guifg=#FA6900      ctermbg=bg  ctermfg=202
+hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#F38630    ctermbg=bg  ctermfg=209
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#798891    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#798891    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/grunge-contrast.vim
+++ b/vim/colors/grunge-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0c0c0a  guifg=#F8F8F2    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0c0c0a  guifg=#F8F8F2    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#D1F2A5   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#D1F2A5   ctermbg=bg ctermfg=193
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#5C634F  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#5C634F  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#D1F2A5    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F56991      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F56991  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F56991      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#D1F2A5    ctermbg=bg  ctermfg=193
+hi Character   guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=204
+hi Number      guibg=bg    guifg=#F56991      ctermbg=bg   ctermfg=204
+hi Boolean     guibg=bg    guifg=#F56991  gui=none    ctermbg=bg   ctermfg=204
+hi Float       guibg=bg    guifg=#F56991      ctermbg=bg   ctermfg=204
 
-hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=204
+hi Statement   guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=204
 
-hi Conditional guibg=bg    guifg=#91A374      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#91A374      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#91A374      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#91A374      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#91A374      ctermbg=bg  ctermfg=108
+hi Repeat      guibg=bg    guifg=#91A374      ctermbg=bg   ctermfg=108
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#91A374      ctermbg=bg   ctermfg=108
+hi Keyword     guibg=bg    guifg=#91A374      ctermbg=bg  ctermfg=108
+hi Exception   guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=204
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#D1F2A5   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#D1F2A5   ctermbg=bg ctermfg=193
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#D1F2A5      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#F56991      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#D1F2A5    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#D1F2A5      ctermbg=bg  ctermfg=193
+hi StorageClass   guibg=bg   guifg=#F56991      ctermbg=bg  ctermfg=204
+hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#D1F2A5    ctermbg=bg  ctermfg=193
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#7f886f    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#7f886f    ctermbg=59   ctermfg=101
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/grunge.vim
+++ b/vim/colors/grunge.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#31332C  guifg=#F8F8F2    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#31332C  guifg=#F8F8F2    gui=none ctermbg=58 ctermfg=231
+hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#D1F2A5   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#D1F2A5   ctermbg=bg ctermfg=193
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#5C634F  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#5C634F  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#D1F2A5    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F56991      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F56991  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F56991      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#D1F2A5    ctermbg=bg  ctermfg=193
+hi Character   guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=204
+hi Number      guibg=bg    guifg=#F56991      ctermbg=bg   ctermfg=204
+hi Boolean     guibg=bg    guifg=#F56991  gui=none    ctermbg=bg   ctermfg=204
+hi Float       guibg=bg    guifg=#F56991      ctermbg=bg   ctermfg=204
 
-hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=204
+hi Statement   guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=204
 
-hi Conditional guibg=bg    guifg=#91A374      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#91A374      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#91A374      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#91A374      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#91A374      ctermbg=bg  ctermfg=108
+hi Repeat      guibg=bg    guifg=#91A374      ctermbg=bg   ctermfg=108
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#91A374      ctermbg=bg   ctermfg=108
+hi Keyword     guibg=bg    guifg=#91A374      ctermbg=bg  ctermfg=108
+hi Exception   guibg=bg    guifg=#F56991      ctermbg=bg  ctermfg=204
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#D1F2A5   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#D1F2A5   ctermbg=bg ctermfg=193
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#D1F2A5      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#F56991      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#D1F2A5    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#D1F2A5      ctermbg=bg  ctermfg=193
+hi StorageClass   guibg=bg   guifg=#F56991      ctermbg=bg  ctermfg=204
+hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#D1F2A5    ctermbg=bg  ctermfg=193
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#7f886f    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#7f886f    ctermbg=59   ctermfg=101
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/halflife-contrast.vim
+++ b/vim/colors/halflife-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#000000  guifg=#cccccc    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#cccccc   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#000000  guifg=#cccccc    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#cccccc   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#FC913A   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#FC913A   ctermbg=bg ctermfg=209
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#555555  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#555555  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F9D423    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F9D423      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F9D423  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F9D423      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F9D423    ctermbg=bg  ctermfg=220
+hi Character   guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=102
+hi Number      guibg=bg    guifg=#F9D423      ctermbg=bg   ctermfg=220
+hi Boolean     guibg=bg    guifg=#F9D423  gui=none    ctermbg=bg   ctermfg=220
+hi Float       guibg=bg    guifg=#F9D423      ctermbg=bg   ctermfg=220
 
-hi Identifier  guibg=bg    guifg=#cccccc      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#cccccc      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=102
+hi Statement   guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=102
 
-hi Conditional guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#7D8991      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#7D8991      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=102
+hi Repeat      guibg=bg    guifg=#7D8991      ctermbg=bg   ctermfg=102
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#7D8991      ctermbg=bg   ctermfg=102
+hi Keyword     guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=102
+hi Exception   guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=102
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#FC913A   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#FC913A   ctermbg=bg ctermfg=209
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#FC913A      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#7D8991      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#cccccc      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#FC913A    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#FC913A      ctermbg=bg  ctermfg=209
+hi StorageClass   guibg=bg   guifg=#7D8991      ctermbg=bg  ctermfg=102
+hi Structure      guibg=bg   guifg=#cccccc      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#FC913A    ctermbg=bg  ctermfg=209
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#808080    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#808080    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#cccccc        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#cccccc        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/halflife.vim
+++ b/vim/colors/halflife.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#222222  guifg=#cccccc    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#cccccc   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#222222  guifg=#cccccc    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#cccccc   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#FC913A   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#FC913A   ctermbg=bg ctermfg=209
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#555555  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#555555  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F9D423    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F9D423      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F9D423  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F9D423      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F9D423    ctermbg=bg  ctermfg=220
+hi Character   guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=102
+hi Number      guibg=bg    guifg=#F9D423      ctermbg=bg   ctermfg=220
+hi Boolean     guibg=bg    guifg=#F9D423  gui=none    ctermbg=bg   ctermfg=220
+hi Float       guibg=bg    guifg=#F9D423      ctermbg=bg   ctermfg=220
 
-hi Identifier  guibg=bg    guifg=#cccccc      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#cccccc      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=102
+hi Statement   guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=102
 
-hi Conditional guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#7D8991      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#7D8991      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=102
+hi Repeat      guibg=bg    guifg=#7D8991      ctermbg=bg   ctermfg=102
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#7D8991      ctermbg=bg   ctermfg=102
+hi Keyword     guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=102
+hi Exception   guibg=bg    guifg=#7D8991      ctermbg=bg  ctermfg=102
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#FC913A   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#FC913A   ctermbg=bg ctermfg=209
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#FC913A      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#7D8991      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#cccccc      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#FC913A    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#FC913A      ctermbg=bg  ctermfg=209
+hi StorageClass   guibg=bg   guifg=#7D8991      ctermbg=bg  ctermfg=102
+hi Structure      guibg=bg   guifg=#cccccc      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#FC913A    ctermbg=bg  ctermfg=209
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#808080    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#808080    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#cccccc        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#cccccc        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/heroku.vim
+++ b/vim/colors/heroku.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#1b1b24  guifg=#c8c7d5    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#c8c7d5   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#1b1b24  guifg=#c8c7d5    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#c8c7d5   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#585480   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#585480   ctermbg=bg ctermfg=60
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#505067  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#505067  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#a6fa62    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#7873ae      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#a6fa62      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#a6fa62  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#a6fa62      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#a6fa62    ctermbg=bg  ctermfg=155
+hi Character   guibg=bg    guifg=#7873ae      ctermbg=bg  ctermfg=103
+hi Number      guibg=bg    guifg=#a6fa62      ctermbg=bg   ctermfg=155
+hi Boolean     guibg=bg    guifg=#a6fa62  gui=none    ctermbg=bg   ctermfg=155
+hi Float       guibg=bg    guifg=#a6fa62      ctermbg=bg   ctermfg=155
 
-hi Identifier  guibg=bg    guifg=#c8c7d5      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#7873ae      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#7873ae      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#c8c7d5      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#7873ae      ctermbg=bg  ctermfg=103
+hi Statement   guibg=bg    guifg=#7873ae      ctermbg=bg  ctermfg=103
 
-hi Conditional guibg=bg    guifg=#7873ae      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#7873ae      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#7873ae      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#7873ae      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#7873ae      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#7873ae      ctermbg=bg  ctermfg=103
+hi Repeat      guibg=bg    guifg=#7873ae      ctermbg=bg   ctermfg=103
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#7873ae      ctermbg=bg   ctermfg=103
+hi Keyword     guibg=bg    guifg=#7873ae      ctermbg=bg  ctermfg=103
+hi Exception   guibg=bg    guifg=#7873ae      ctermbg=bg  ctermfg=103
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#585480   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#585480   ctermbg=bg ctermfg=60
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#585480      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#7873ae      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#c8c7d5      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#585480    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#585480      ctermbg=bg  ctermfg=60
+hi StorageClass   guibg=bg   guifg=#7873ae      ctermbg=bg  ctermfg=103
+hi Structure      guibg=bg   guifg=#c8c7d5      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#585480    ctermbg=bg  ctermfg=60
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#5d5d76    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#5d5d76    ctermbg=59   ctermfg=60
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#c8c7d5        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#c8c7d5        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/hyrule-contrast.vim
+++ b/vim/colors/hyrule-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0c0c0c  guifg=#c0d5c1    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#c0d5c1   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0c0c0c  guifg=#c0d5c1    gui=none ctermbg=16 ctermfg=151
+hi NonText     guibg=bg  guifg=#c0d5c1   ctermbg=bg ctermfg=151
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#f5c504   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#f5c504   ctermbg=bg ctermfg=220
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#716d6a  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#716d6a  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#ce830d    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#f5c504      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#f5c504  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#f5c504      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#ce830d    ctermbg=bg  ctermfg=172
+hi Character   guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=70
+hi Number      guibg=bg    guifg=#f5c504      ctermbg=bg   ctermfg=220
+hi Boolean     guibg=bg    guifg=#f5c504  gui=none    ctermbg=bg   ctermfg=220
+hi Float       guibg=bg    guifg=#f5c504      ctermbg=bg   ctermfg=220
 
-hi Identifier  guibg=bg    guifg=#c0d5c1      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#c0d5c1      ctermbg=bg  ctermfg=151
+hi Function    guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=70
+hi Statement   guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=70
 
-hi Conditional guibg=bg    guifg=#90c93f      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#90c93f      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#90c93f      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#90c93f      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#90c93f      ctermbg=bg  ctermfg=113
+hi Repeat      guibg=bg    guifg=#90c93f      ctermbg=bg   ctermfg=113
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#90c93f      ctermbg=bg   ctermfg=113
+hi Keyword     guibg=bg    guifg=#90c93f      ctermbg=bg  ctermfg=113
+hi Exception   guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=70
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#f5c504   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#f5c504   ctermbg=bg ctermfg=220
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#f5c504      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#569e16      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#c0d5c1      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#f5c504    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#f5c504      ctermbg=bg  ctermfg=220
+hi StorageClass   guibg=bg   guifg=#569e16      ctermbg=bg  ctermfg=70
+hi Structure      guibg=bg   guifg=#c0d5c1      ctermbg=bg  ctermfg=151
+hi Typedef    guibg=bg   guifg=#f5c504    ctermbg=bg  ctermfg=220
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#9e9a98    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#9e9a98    ctermbg=59   ctermfg=138
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#c0d5c1        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#c0d5c1        ctermbg=bg   ctermfg=151
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/hyrule.vim
+++ b/vim/colors/hyrule.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2d2c2b  guifg=#c0d5c1    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#c0d5c1   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2d2c2b  guifg=#c0d5c1    gui=none ctermbg=16 ctermfg=151
+hi NonText     guibg=bg  guifg=#c0d5c1   ctermbg=bg ctermfg=151
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#f5c504   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#f5c504   ctermbg=bg ctermfg=220
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#716d6a  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#716d6a  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#ce830d    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#f5c504      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#f5c504  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#f5c504      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#ce830d    ctermbg=bg  ctermfg=172
+hi Character   guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=70
+hi Number      guibg=bg    guifg=#f5c504      ctermbg=bg   ctermfg=220
+hi Boolean     guibg=bg    guifg=#f5c504  gui=none    ctermbg=bg   ctermfg=220
+hi Float       guibg=bg    guifg=#f5c504      ctermbg=bg   ctermfg=220
 
-hi Identifier  guibg=bg    guifg=#c0d5c1      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#c0d5c1      ctermbg=bg  ctermfg=151
+hi Function    guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=70
+hi Statement   guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=70
 
-hi Conditional guibg=bg    guifg=#90c93f      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#90c93f      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#90c93f      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#90c93f      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#90c93f      ctermbg=bg  ctermfg=113
+hi Repeat      guibg=bg    guifg=#90c93f      ctermbg=bg   ctermfg=113
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#90c93f      ctermbg=bg   ctermfg=113
+hi Keyword     guibg=bg    guifg=#90c93f      ctermbg=bg  ctermfg=113
+hi Exception   guibg=bg    guifg=#569e16      ctermbg=bg  ctermfg=70
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#f5c504   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#f5c504   ctermbg=bg ctermfg=220
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#f5c504      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#569e16      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#c0d5c1      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#f5c504    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#f5c504      ctermbg=bg  ctermfg=220
+hi StorageClass   guibg=bg   guifg=#569e16      ctermbg=bg  ctermfg=70
+hi Structure      guibg=bg   guifg=#c0d5c1      ctermbg=bg  ctermfg=151
+hi Typedef    guibg=bg   guifg=#f5c504    ctermbg=bg  ctermfg=220
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#9e9a98    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#9e9a98    ctermbg=59   ctermfg=138
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#c0d5c1        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#c0d5c1        ctermbg=bg   ctermfg=151
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/iceberg-contrast.vim
+++ b/vim/colors/iceberg-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0b0e0e  guifg=#BDD6DB    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#BDD6DB   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0b0e0e  guifg=#BDD6DB    gui=none ctermbg=16 ctermfg=152
+hi NonText     guibg=bg  guifg=#BDD6DB   ctermbg=bg ctermfg=152
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#59C0E3   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#59C0E3   ctermbg=bg ctermfg=74
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#537178  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#537178  gui=none    ctermbg=bg   ctermfg=60
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#FFFFFF    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#FFFFFF      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#FFFFFF  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#FFFFFF      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#FFFFFF    ctermbg=bg  ctermfg=231
+hi Character   guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=31
+hi Number      guibg=bg    guifg=#FFFFFF      ctermbg=bg   ctermfg=231
+hi Boolean     guibg=bg    guifg=#FFFFFF  gui=none    ctermbg=bg   ctermfg=231
+hi Float       guibg=bg    guifg=#FFFFFF      ctermbg=bg   ctermfg=231
 
-hi Identifier  guibg=bg    guifg=#BDD6DB      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#BDD6DB      ctermbg=bg  ctermfg=152
+hi Function    guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=31
+hi Statement   guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=31
 
-hi Conditional guibg=bg    guifg=#B1E2F2      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#B1E2F2      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#B1E2F2      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#B1E2F2      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#B1E2F2      ctermbg=bg  ctermfg=153
+hi Repeat      guibg=bg    guifg=#B1E2F2      ctermbg=bg   ctermfg=153
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#B1E2F2      ctermbg=bg   ctermfg=153
+hi Keyword     guibg=bg    guifg=#B1E2F2      ctermbg=bg  ctermfg=153
+hi Exception   guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=31
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#59C0E3   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#59C0E3   ctermbg=bg ctermfg=74
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#59C0E3      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#2D8DA1      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#BDD6DB      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#59C0E3    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#59C0E3      ctermbg=bg  ctermfg=74
+hi StorageClass   guibg=bg   guifg=#2D8DA1      ctermbg=bg  ctermfg=31
+hi Structure      guibg=bg   guifg=#BDD6DB      ctermbg=bg  ctermfg=152
+hi Typedef    guibg=bg   guifg=#59C0E3    ctermbg=bg  ctermfg=74
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#79a2ab    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#79a2ab    ctermbg=59   ctermfg=109
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#BDD6DB        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#BDD6DB        ctermbg=bg   ctermfg=152
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/iceberg.vim
+++ b/vim/colors/iceberg.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#323B3D  guifg=#BDD6DB    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#BDD6DB   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#323B3D  guifg=#BDD6DB    gui=none ctermbg=59 ctermfg=152
+hi NonText     guibg=bg  guifg=#BDD6DB   ctermbg=bg ctermfg=152
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#59C0E3   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#59C0E3   ctermbg=bg ctermfg=74
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#537178  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#537178  gui=none    ctermbg=bg   ctermfg=60
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#FFFFFF    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#FFFFFF      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#FFFFFF  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#FFFFFF      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#FFFFFF    ctermbg=bg  ctermfg=231
+hi Character   guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=31
+hi Number      guibg=bg    guifg=#FFFFFF      ctermbg=bg   ctermfg=231
+hi Boolean     guibg=bg    guifg=#FFFFFF  gui=none    ctermbg=bg   ctermfg=231
+hi Float       guibg=bg    guifg=#FFFFFF      ctermbg=bg   ctermfg=231
 
-hi Identifier  guibg=bg    guifg=#BDD6DB      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#BDD6DB      ctermbg=bg  ctermfg=152
+hi Function    guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=31
+hi Statement   guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=31
 
-hi Conditional guibg=bg    guifg=#B1E2F2      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#B1E2F2      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#B1E2F2      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#B1E2F2      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#B1E2F2      ctermbg=bg  ctermfg=153
+hi Repeat      guibg=bg    guifg=#B1E2F2      ctermbg=bg   ctermfg=153
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#B1E2F2      ctermbg=bg   ctermfg=153
+hi Keyword     guibg=bg    guifg=#B1E2F2      ctermbg=bg  ctermfg=153
+hi Exception   guibg=bg    guifg=#2D8DA1      ctermbg=bg  ctermfg=31
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#59C0E3   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#59C0E3   ctermbg=bg ctermfg=74
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#59C0E3      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#2D8DA1      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#BDD6DB      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#59C0E3    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#59C0E3      ctermbg=bg  ctermfg=74
+hi StorageClass   guibg=bg   guifg=#2D8DA1      ctermbg=bg  ctermfg=31
+hi Structure      guibg=bg   guifg=#BDD6DB      ctermbg=bg  ctermfg=152
+hi Typedef    guibg=bg   guifg=#59C0E3    ctermbg=bg  ctermfg=74
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#79a2ab    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#79a2ab    ctermbg=59   ctermfg=109
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#BDD6DB        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#BDD6DB        ctermbg=bg   ctermfg=152
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/juicy-contrast.vim
+++ b/vim/colors/juicy-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#000000  guifg=#e3e2e0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#e3e2e0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#000000  guifg=#e3e2e0    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#e3e2e0   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#FF4E50   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#FF4E50   ctermbg=bg ctermfg=203
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#777777  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#777777  gui=none    ctermbg=bg   ctermfg=102
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#3bc7b8    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#CE1836      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#CE1836  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#CE1836      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#3bc7b8    ctermbg=bg  ctermfg=79
+hi Character   guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=79
+hi Number      guibg=bg    guifg=#CE1836      ctermbg=bg   ctermfg=161
+hi Boolean     guibg=bg    guifg=#CE1836  gui=none    ctermbg=bg   ctermfg=161
+hi Float       guibg=bg    guifg=#CE1836      ctermbg=bg   ctermfg=161
 
-hi Identifier  guibg=bg    guifg=#e3e2e0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#e3e2e0      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=79
+hi Statement   guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=79
 
-hi Conditional guibg=bg    guifg=#EDB92E      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#EDB92E      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#EDB92E      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#EDB92E      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#EDB92E      ctermbg=bg  ctermfg=214
+hi Repeat      guibg=bg    guifg=#EDB92E      ctermbg=bg   ctermfg=214
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#EDB92E      ctermbg=bg   ctermfg=214
+hi Keyword     guibg=bg    guifg=#EDB92E      ctermbg=bg  ctermfg=214
+hi Exception   guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=79
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#FF4E50   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#FF4E50   ctermbg=bg ctermfg=203
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#FF4E50      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#3bc7b8      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#e3e2e0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#FF4E50    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#FF4E50      ctermbg=bg  ctermfg=203
+hi StorageClass   guibg=bg   guifg=#3bc7b8      ctermbg=bg  ctermfg=79
+hi Structure      guibg=bg   guifg=#e3e2e0      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#FF4E50    ctermbg=bg  ctermfg=203
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#9b9b9b    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#9b9b9b    ctermbg=59   ctermfg=145
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#e3e2e0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#e3e2e0        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/juicy.vim
+++ b/vim/colors/juicy.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#222222  guifg=#e3e2e0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#e3e2e0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#222222  guifg=#e3e2e0    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#e3e2e0   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#FF4E50   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#FF4E50   ctermbg=bg ctermfg=203
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#777777  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#777777  gui=none    ctermbg=bg   ctermfg=102
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#3bc7b8    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#CE1836      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#CE1836  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#CE1836      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#3bc7b8    ctermbg=bg  ctermfg=79
+hi Character   guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=79
+hi Number      guibg=bg    guifg=#CE1836      ctermbg=bg   ctermfg=161
+hi Boolean     guibg=bg    guifg=#CE1836  gui=none    ctermbg=bg   ctermfg=161
+hi Float       guibg=bg    guifg=#CE1836      ctermbg=bg   ctermfg=161
 
-hi Identifier  guibg=bg    guifg=#e3e2e0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#e3e2e0      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=79
+hi Statement   guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=79
 
-hi Conditional guibg=bg    guifg=#EDB92E      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#EDB92E      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#EDB92E      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#EDB92E      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#EDB92E      ctermbg=bg  ctermfg=214
+hi Repeat      guibg=bg    guifg=#EDB92E      ctermbg=bg   ctermfg=214
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#EDB92E      ctermbg=bg   ctermfg=214
+hi Keyword     guibg=bg    guifg=#EDB92E      ctermbg=bg  ctermfg=214
+hi Exception   guibg=bg    guifg=#3bc7b8      ctermbg=bg  ctermfg=79
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#FF4E50   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#FF4E50   ctermbg=bg ctermfg=203
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#FF4E50      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#3bc7b8      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#e3e2e0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#FF4E50    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#FF4E50      ctermbg=bg  ctermfg=203
+hi StorageClass   guibg=bg   guifg=#3bc7b8      ctermbg=bg  ctermfg=79
+hi Structure      guibg=bg   guifg=#e3e2e0      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#FF4E50    ctermbg=bg  ctermfg=203
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#9b9b9b    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#9b9b9b    ctermbg=59   ctermfg=145
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#e3e2e0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#e3e2e0        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/keen-contrast.vim
+++ b/vim/colors/keen-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#000000  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#000000  guifg=#ffffff    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#6F8B94   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#6F8B94   ctermbg=bg ctermfg=66
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#374c60  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#374c60  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#b5db99    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#b5db99      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#b5db99  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#b5db99      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#b5db99    ctermbg=bg  ctermfg=150
+hi Character   guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=97
+hi Number      guibg=bg    guifg=#b5db99      ctermbg=bg   ctermfg=150
+hi Boolean     guibg=bg    guifg=#b5db99  gui=none    ctermbg=bg   ctermfg=150
+hi Float       guibg=bg    guifg=#b5db99      ctermbg=bg   ctermfg=150
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=97
+hi Statement   guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=97
 
-hi Conditional guibg=bg    guifg=#6F8B94      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#6F8B94      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#6F8B94      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#6F8B94      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#6F8B94      ctermbg=bg  ctermfg=66
+hi Repeat      guibg=bg    guifg=#6F8B94      ctermbg=bg   ctermfg=66
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#6F8B94      ctermbg=bg   ctermfg=66
+hi Keyword     guibg=bg    guifg=#6F8B94      ctermbg=bg  ctermfg=66
+hi Exception   guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=97
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#6F8B94   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#6F8B94   ctermbg=bg ctermfg=66
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#6F8B94      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#8767b7      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#6F8B94    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#6F8B94      ctermbg=bg  ctermfg=66
+hi StorageClass   guibg=bg   guifg=#8767b7      ctermbg=bg  ctermfg=97
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#6F8B94    ctermbg=bg  ctermfg=66
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#56738e    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#56738e    ctermbg=59   ctermfg=66
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/keen.vim
+++ b/vim/colors/keen.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#111111  guifg=#cccccc    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#cccccc   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#111111  guifg=#cccccc    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#cccccc   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#6F8B94   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#6F8B94   ctermbg=bg ctermfg=66
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#374c60  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#374c60  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#b5db99    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#b5db99      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#b5db99  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#b5db99      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#b5db99    ctermbg=bg  ctermfg=150
+hi Character   guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=97
+hi Number      guibg=bg    guifg=#b5db99      ctermbg=bg   ctermfg=150
+hi Boolean     guibg=bg    guifg=#b5db99  gui=none    ctermbg=bg   ctermfg=150
+hi Float       guibg=bg    guifg=#b5db99      ctermbg=bg   ctermfg=150
 
-hi Identifier  guibg=bg    guifg=#cccccc      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#cccccc      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=97
+hi Statement   guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=97
 
-hi Conditional guibg=bg    guifg=#6F8B94      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#6F8B94      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#6F8B94      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#6F8B94      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#6F8B94      ctermbg=bg  ctermfg=66
+hi Repeat      guibg=bg    guifg=#6F8B94      ctermbg=bg   ctermfg=66
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#6F8B94      ctermbg=bg   ctermfg=66
+hi Keyword     guibg=bg    guifg=#6F8B94      ctermbg=bg  ctermfg=66
+hi Exception   guibg=bg    guifg=#8767b7      ctermbg=bg  ctermfg=97
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#6F8B94   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#6F8B94   ctermbg=bg ctermfg=66
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#6F8B94      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#8767b7      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#cccccc      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#6F8B94    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#6F8B94      ctermbg=bg  ctermfg=66
+hi StorageClass   guibg=bg   guifg=#8767b7      ctermbg=bg  ctermfg=97
+hi Structure      guibg=bg   guifg=#cccccc      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#6F8B94    ctermbg=bg  ctermfg=66
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#56738e    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#56738e    ctermbg=59   ctermfg=66
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#cccccc        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#cccccc        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/kiwi.vim
+++ b/vim/colors/kiwi.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#161a19  guifg=#EDEBE6    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#EDEBE6   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#161a19  guifg=#EDEBE6    gui=none ctermbg=16 ctermfg=230
+hi NonText     guibg=bg  guifg=#EDEBE6   ctermbg=bg ctermfg=230
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#229986   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#229986   ctermbg=bg ctermfg=30
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#354341  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#354341  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#a1e6c1    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#95C72A      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#a1e6c1      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#a1e6c1  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#a1e6c1      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#a1e6c1    ctermbg=bg  ctermfg=151
+hi Character   guibg=bg    guifg=#95C72A      ctermbg=bg  ctermfg=112
+hi Number      guibg=bg    guifg=#a1e6c1      ctermbg=bg   ctermfg=151
+hi Boolean     guibg=bg    guifg=#a1e6c1  gui=none    ctermbg=bg   ctermfg=151
+hi Float       guibg=bg    guifg=#a1e6c1      ctermbg=bg   ctermfg=151
 
-hi Identifier  guibg=bg    guifg=#EDEBE6      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#95C72A      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#95C72A      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#EDEBE6      ctermbg=bg  ctermfg=230
+hi Function    guibg=bg    guifg=#95C72A      ctermbg=bg  ctermfg=112
+hi Statement   guibg=bg    guifg=#95C72A      ctermbg=bg  ctermfg=112
 
-hi Conditional guibg=bg    guifg=#229986      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#229986      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#229986      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#229986      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#95C72A      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#229986      ctermbg=bg  ctermfg=30
+hi Repeat      guibg=bg    guifg=#229986      ctermbg=bg   ctermfg=30
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#229986      ctermbg=bg   ctermfg=30
+hi Keyword     guibg=bg    guifg=#229986      ctermbg=bg  ctermfg=30
+hi Exception   guibg=bg    guifg=#95C72A      ctermbg=bg  ctermfg=112
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#229986   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#229986   ctermbg=bg ctermfg=30
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#229986      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#95C72A      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#EDEBE6      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#229986    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#229986      ctermbg=bg  ctermfg=30
+hi StorageClass   guibg=bg   guifg=#95C72A      ctermbg=bg  ctermfg=112
+hi Structure      guibg=bg   guifg=#EDEBE6      ctermbg=bg  ctermfg=230
+hi Typedef    guibg=bg   guifg=#229986    ctermbg=bg  ctermfg=30
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#5b7a75    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#5b7a75    ctermbg=59   ctermfg=66
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#EDEBE6        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#EDEBE6        ctermbg=bg   ctermfg=230
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/laravel-contrast.vim
+++ b/vim/colors/laravel-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#000000  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#000000  guifg=#ffffff    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#FFC48C   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#FFC48C   ctermbg=bg ctermfg=222
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#615953  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#615953  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#FDCA49    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#FC580C      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#FC580C  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#FC580C      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#FDCA49    ctermbg=bg  ctermfg=221
+hi Character   guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=202
+hi Number      guibg=bg    guifg=#FC580C      ctermbg=bg   ctermfg=202
+hi Boolean     guibg=bg    guifg=#FC580C  gui=none    ctermbg=bg   ctermfg=202
+hi Float       guibg=bg    guifg=#FC580C      ctermbg=bg   ctermfg=202
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=202
+hi Statement   guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=202
 
-hi Conditional guibg=bg    guifg=#FFA927      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#FFA927      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#FFA927      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#FFA927      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#FFA927      ctermbg=bg  ctermfg=214
+hi Repeat      guibg=bg    guifg=#FFA927      ctermbg=bg   ctermfg=214
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#FFA927      ctermbg=bg   ctermfg=214
+hi Keyword     guibg=bg    guifg=#FFA927      ctermbg=bg  ctermfg=214
+hi Exception   guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=202
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#FFC48C   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#FFC48C   ctermbg=bg ctermfg=222
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#FFC48C      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#FC6B0A      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#FFC48C    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#FFC48C      ctermbg=bg  ctermfg=222
+hi StorageClass   guibg=bg   guifg=#FC6B0A      ctermbg=bg  ctermfg=202
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#FFC48C    ctermbg=bg  ctermfg=222
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#8e8279    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#8e8279    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/laravel.vim
+++ b/vim/colors/laravel.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2E2C2B  guifg=#DEDEDE    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2E2C2B  guifg=#DEDEDE    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#FFC48C   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#FFC48C   ctermbg=bg ctermfg=222
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#615953  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#615953  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#FDCA49    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#FC580C      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#FC580C  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#FC580C      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#FDCA49    ctermbg=bg  ctermfg=221
+hi Character   guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=202
+hi Number      guibg=bg    guifg=#FC580C      ctermbg=bg   ctermfg=202
+hi Boolean     guibg=bg    guifg=#FC580C  gui=none    ctermbg=bg   ctermfg=202
+hi Float       guibg=bg    guifg=#FC580C      ctermbg=bg   ctermfg=202
 
-hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=202
+hi Statement   guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=202
 
-hi Conditional guibg=bg    guifg=#FFA927      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#FFA927      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#FFA927      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#FFA927      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#FFA927      ctermbg=bg  ctermfg=214
+hi Repeat      guibg=bg    guifg=#FFA927      ctermbg=bg   ctermfg=214
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#FFA927      ctermbg=bg   ctermfg=214
+hi Keyword     guibg=bg    guifg=#FFA927      ctermbg=bg  ctermfg=214
+hi Exception   guibg=bg    guifg=#FC6B0A      ctermbg=bg  ctermfg=202
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#FFC48C   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#FFC48C   ctermbg=bg ctermfg=222
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#FFC48C      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#FC6B0A      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#FFC48C    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#FFC48C      ctermbg=bg  ctermfg=222
+hi StorageClass   guibg=bg   guifg=#FC6B0A      ctermbg=bg  ctermfg=202
+hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#FFC48C    ctermbg=bg  ctermfg=222
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#8e8279    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#8e8279    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/lavender-contrast.vim
+++ b/vim/colors/lavender-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#080709  guifg=#E0CEED    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#E0CEED   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#080709  guifg=#E0CEED    gui=none ctermbg=16 ctermfg=189
+hi NonText     guibg=bg  guifg=#E0CEED   ctermbg=bg ctermfg=189
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#A29DFA   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#A29DFA   ctermbg=bg ctermfg=147
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#614e6e  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#614e6e  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F5B0EF    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F25AE6      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F25AE6  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F25AE6      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F5B0EF    ctermbg=bg  ctermfg=219
+hi Character   guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=135
+hi Number      guibg=bg    guifg=#F25AE6      ctermbg=bg   ctermfg=206
+hi Boolean     guibg=bg    guifg=#F25AE6  gui=none    ctermbg=bg   ctermfg=206
+hi Float       guibg=bg    guifg=#F25AE6      ctermbg=bg   ctermfg=206
 
-hi Identifier  guibg=bg    guifg=#E0CEED      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#E0CEED      ctermbg=bg  ctermfg=189
+hi Function    guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=135
+hi Statement   guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=135
 
-hi Conditional guibg=bg    guifg=#8E6DA6      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#8E6DA6      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#8E6DA6      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#8E6DA6      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#8E6DA6      ctermbg=bg  ctermfg=97
+hi Repeat      guibg=bg    guifg=#8E6DA6      ctermbg=bg   ctermfg=97
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#8E6DA6      ctermbg=bg   ctermfg=97
+hi Keyword     guibg=bg    guifg=#8E6DA6      ctermbg=bg  ctermfg=97
+hi Exception   guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=135
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#A29DFA   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#A29DFA   ctermbg=bg ctermfg=147
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#A29DFA      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#B657FF      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#E0CEED      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#A29DFA    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#A29DFA      ctermbg=bg  ctermfg=147
+hi StorageClass   guibg=bg   guifg=#B657FF      ctermbg=bg  ctermfg=135
+hi Structure      guibg=bg   guifg=#E0CEED      ctermbg=bg  ctermfg=189
+hi Typedef    guibg=bg   guifg=#A29DFA    ctermbg=bg  ctermfg=147
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#9076a1    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#9076a1    ctermbg=59   ctermfg=103
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#E0CEED        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#E0CEED        ctermbg=bg   ctermfg=189
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/lavender.vim
+++ b/vim/colors/lavender.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#29222E  guifg=#E0CEED    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#E0CEED   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#29222E  guifg=#E0CEED    gui=none ctermbg=16 ctermfg=189
+hi NonText     guibg=bg  guifg=#E0CEED   ctermbg=bg ctermfg=189
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#A29DFA   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#A29DFA   ctermbg=bg ctermfg=147
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#614e6e  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#614e6e  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F5B0EF    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F25AE6      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F25AE6  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F25AE6      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F5B0EF    ctermbg=bg  ctermfg=219
+hi Character   guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=135
+hi Number      guibg=bg    guifg=#F25AE6      ctermbg=bg   ctermfg=206
+hi Boolean     guibg=bg    guifg=#F25AE6  gui=none    ctermbg=bg   ctermfg=206
+hi Float       guibg=bg    guifg=#F25AE6      ctermbg=bg   ctermfg=206
 
-hi Identifier  guibg=bg    guifg=#E0CEED      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#E0CEED      ctermbg=bg  ctermfg=189
+hi Function    guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=135
+hi Statement   guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=135
 
-hi Conditional guibg=bg    guifg=#8E6DA6      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#8E6DA6      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#8E6DA6      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#8E6DA6      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#8E6DA6      ctermbg=bg  ctermfg=97
+hi Repeat      guibg=bg    guifg=#8E6DA6      ctermbg=bg   ctermfg=97
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#8E6DA6      ctermbg=bg   ctermfg=97
+hi Keyword     guibg=bg    guifg=#8E6DA6      ctermbg=bg  ctermfg=97
+hi Exception   guibg=bg    guifg=#B657FF      ctermbg=bg  ctermfg=135
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#A29DFA   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#A29DFA   ctermbg=bg ctermfg=147
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#A29DFA      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#B657FF      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#E0CEED      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#A29DFA    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#A29DFA      ctermbg=bg  ctermfg=147
+hi StorageClass   guibg=bg   guifg=#B657FF      ctermbg=bg  ctermfg=135
+hi Structure      guibg=bg   guifg=#E0CEED      ctermbg=bg  ctermfg=189
+hi Typedef    guibg=bg   guifg=#A29DFA    ctermbg=bg  ctermfg=147
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#9076a1    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#9076a1    ctermbg=59   ctermfg=103
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#E0CEED        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#E0CEED        ctermbg=bg   ctermfg=189
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/legacy.vim
+++ b/vim/colors/legacy.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#14191f  guifg=#aec2e0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#aec2e0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#14191f  guifg=#aec2e0    gui=none ctermbg=16 ctermfg=146
+hi NonText     guibg=bg  guifg=#aec2e0   ctermbg=bg ctermfg=146
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#267fb5   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#267fb5   ctermbg=bg ctermfg=31
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#324357  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#324357  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#FF410D    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#C7F026      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#C7F026  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#C7F026      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#FF410D    ctermbg=bg  ctermfg=202
+hi Character   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Number      guibg=bg    guifg=#C7F026      ctermbg=bg   ctermfg=190
+hi Boolean     guibg=bg    guifg=#C7F026  gui=none    ctermbg=bg   ctermfg=190
+hi Float       guibg=bg    guifg=#C7F026      ctermbg=bg   ctermfg=190
 
-hi Identifier  guibg=bg    guifg=#aec2e0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#aec2e0      ctermbg=bg  ctermfg=146
+hi Function    guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Statement   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
 
-hi Conditional guibg=bg    guifg=#748aa6      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#748aa6      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#748aa6      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#748aa6      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#748aa6      ctermbg=bg  ctermfg=103
+hi Repeat      guibg=bg    guifg=#748aa6      ctermbg=bg   ctermfg=103
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#748aa6      ctermbg=bg   ctermfg=103
+hi Keyword     guibg=bg    guifg=#748aa6      ctermbg=bg  ctermfg=103
+hi Exception   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#267fb5   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#267fb5   ctermbg=bg ctermfg=31
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#267fb5      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#aec2e0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#267fb5    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#267fb5      ctermbg=bg  ctermfg=31
+hi StorageClass   guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Structure      guibg=bg   guifg=#aec2e0      ctermbg=bg  ctermfg=146
+hi Typedef    guibg=bg   guifg=#267fb5    ctermbg=bg  ctermfg=31
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#4d6785    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#4d6785    ctermbg=59   ctermfg=60
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#aec2e0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#aec2e0        ctermbg=bg   ctermfg=146
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/mellow-contrast.vim
+++ b/vim/colors/mellow-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0b0a09  guifg=#F8F8F2    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0b0a09  guifg=#F8F8F2    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#F2BC79   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#F2BC79   ctermbg=bg ctermfg=216
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F8BB39      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F8BB39  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F8BB39      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=215
+hi Character   guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=30
+hi Number      guibg=bg    guifg=#F8BB39      ctermbg=bg   ctermfg=215
+hi Boolean     guibg=bg    guifg=#F8BB39  gui=none    ctermbg=bg   ctermfg=215
+hi Float       guibg=bg    guifg=#F8BB39      ctermbg=bg   ctermfg=215
 
-hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=30
+hi Statement   guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=30
 
-hi Conditional guibg=bg    guifg=#F2BC79      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#F2BC79      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#F2BC79      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#F2BC79      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#F2BC79      ctermbg=bg  ctermfg=216
+hi Repeat      guibg=bg    guifg=#F2BC79      ctermbg=bg   ctermfg=216
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#F2BC79      ctermbg=bg   ctermfg=216
+hi Keyword     guibg=bg    guifg=#F2BC79      ctermbg=bg  ctermfg=216
+hi Exception   guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=30
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#F2BC79   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#F2BC79   ctermbg=bg ctermfg=216
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#F2BC79      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#1F8181      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#F2BC79    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#F2BC79      ctermbg=bg  ctermfg=216
+hi StorageClass   guibg=bg   guifg=#1F8181      ctermbg=bg  ctermfg=30
+hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#F2BC79    ctermbg=bg  ctermfg=216
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#a09688    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#a09688    ctermbg=59   ctermfg=138
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/mellow.vim
+++ b/vim/colors/mellow.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#36312C  guifg=#F8F8F2    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#36312C  guifg=#F8F8F2    gui=none ctermbg=58 ctermfg=231
+hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#F2BC79   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#F2BC79   ctermbg=bg ctermfg=216
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F8BB39      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F8BB39  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F8BB39      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F8BB39    ctermbg=bg  ctermfg=215
+hi Character   guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=30
+hi Number      guibg=bg    guifg=#F8BB39      ctermbg=bg   ctermfg=215
+hi Boolean     guibg=bg    guifg=#F8BB39  gui=none    ctermbg=bg   ctermfg=215
+hi Float       guibg=bg    guifg=#F8BB39      ctermbg=bg   ctermfg=215
 
-hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=30
+hi Statement   guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=30
 
-hi Conditional guibg=bg    guifg=#F2BC79      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#F2BC79      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#F2BC79      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#F2BC79      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#F2BC79      ctermbg=bg  ctermfg=216
+hi Repeat      guibg=bg    guifg=#F2BC79      ctermbg=bg   ctermfg=216
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#F2BC79      ctermbg=bg   ctermfg=216
+hi Keyword     guibg=bg    guifg=#F2BC79      ctermbg=bg  ctermfg=216
+hi Exception   guibg=bg    guifg=#1F8181      ctermbg=bg  ctermfg=30
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#F2BC79   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#F2BC79   ctermbg=bg ctermfg=216
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#F2BC79      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#1F8181      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#F2BC79    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#F2BC79      ctermbg=bg  ctermfg=216
+hi StorageClass   guibg=bg   guifg=#1F8181      ctermbg=bg  ctermfg=30
+hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#F2BC79    ctermbg=bg  ctermfg=216
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#a09688    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#a09688    ctermbg=59   ctermfg=138
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/mintchoc.vim
+++ b/vim/colors/mintchoc.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2b221c  guifg=#BABABA    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#BABABA   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2b221c  guifg=#BABABA    gui=none ctermbg=16 ctermfg=145
+hi NonText     guibg=bg  guifg=#BABABA   ctermbg=bg ctermfg=145
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#9D8262   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#9D8262   ctermbg=bg ctermfg=137
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#564439  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#564439  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#00E08C    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#008D62      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#00E08C      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#00E08C  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#00E08C      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#00E08C    ctermbg=bg  ctermfg=42
+hi Character   guibg=bg    guifg=#008D62      ctermbg=bg  ctermfg=29
+hi Number      guibg=bg    guifg=#00E08C      ctermbg=bg   ctermfg=42
+hi Boolean     guibg=bg    guifg=#00E08C  gui=none    ctermbg=bg   ctermfg=42
+hi Float       guibg=bg    guifg=#00E08C      ctermbg=bg   ctermfg=42
 
-hi Identifier  guibg=bg    guifg=#BABABA      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#008D62      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#008D62      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#BABABA      ctermbg=bg  ctermfg=145
+hi Function    guibg=bg    guifg=#008D62      ctermbg=bg  ctermfg=29
+hi Statement   guibg=bg    guifg=#008D62      ctermbg=bg  ctermfg=29
 
-hi Conditional guibg=bg    guifg=#9D8262      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#9D8262      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#9D8262      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#9D8262      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#008D62      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#9D8262      ctermbg=bg  ctermfg=137
+hi Repeat      guibg=bg    guifg=#9D8262      ctermbg=bg   ctermfg=137
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#9D8262      ctermbg=bg   ctermfg=137
+hi Keyword     guibg=bg    guifg=#9D8262      ctermbg=bg  ctermfg=137
+hi Exception   guibg=bg    guifg=#008D62      ctermbg=bg  ctermfg=29
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#9D8262   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#9D8262   ctermbg=bg ctermfg=137
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#9D8262      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#008D62      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#BABABA      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#9D8262    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#9D8262      ctermbg=bg  ctermfg=137
+hi StorageClass   guibg=bg   guifg=#008D62      ctermbg=bg  ctermfg=29
+hi Structure      guibg=bg   guifg=#BABABA      ctermbg=bg  ctermfg=145
+hi Typedef    guibg=bg   guifg=#9D8262    ctermbg=bg  ctermfg=137
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#775a47    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#775a47    ctermbg=59   ctermfg=95
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#BABABA        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#BABABA        ctermbg=bg   ctermfg=145
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/mud-contrast.vim
+++ b/vim/colors/mud-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0d0b0b  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0d0b0b  guifg=#ffffff    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#f2c12f   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#f2c12f   ctermbg=bg ctermfg=214
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#524343  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#524343  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#b5db99    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#f55239      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#b5db99      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#b5db99  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#b5db99      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#b5db99    ctermbg=bg  ctermfg=150
+hi Character   guibg=bg    guifg=#f55239      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#b5db99      ctermbg=bg   ctermfg=150
+hi Boolean     guibg=bg    guifg=#b5db99  gui=none    ctermbg=bg   ctermfg=150
+hi Float       guibg=bg    guifg=#b5db99      ctermbg=bg   ctermfg=150
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#f55239      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#f55239      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#f55239      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#f55239      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#f8553c      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#f8553c      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#f8553c      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#f8553c      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#f55239      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#f8553c      ctermbg=bg  ctermfg=203
+hi Repeat      guibg=bg    guifg=#f8553c      ctermbg=bg   ctermfg=203
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#f8553c      ctermbg=bg   ctermfg=203
+hi Keyword     guibg=bg    guifg=#f8553c      ctermbg=bg  ctermfg=203
+hi Exception   guibg=bg    guifg=#f55239      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#f2c12f   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#f2c12f   ctermbg=bg ctermfg=214
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#f2c12f      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#f55239      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#f2c12f    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#f2c12f      ctermbg=bg  ctermfg=214
+hi StorageClass   guibg=bg   guifg=#f55239      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#f2c12f    ctermbg=bg  ctermfg=214
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#e3d7d6    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#e3d7d6    ctermbg=59   ctermfg=188
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/mud.vim
+++ b/vim/colors/mud.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#403635  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#403635  guifg=#ffffff    gui=none ctermbg=59 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#e9c865   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#e9c865   ctermbg=bg ctermfg=185
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#c3b8b7  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#c3b8b7  gui=none    ctermbg=bg   ctermfg=181
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#b5db99    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#FF9787      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#b5db99      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#b5db99  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#b5db99      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#b5db99    ctermbg=bg  ctermfg=150
+hi Character   guibg=bg    guifg=#FF9787      ctermbg=bg  ctermfg=210
+hi Number      guibg=bg    guifg=#b5db99      ctermbg=bg   ctermfg=150
+hi Boolean     guibg=bg    guifg=#b5db99  gui=none    ctermbg=bg   ctermfg=150
+hi Float       guibg=bg    guifg=#b5db99      ctermbg=bg   ctermfg=150
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#FF9787      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#FF9787      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#FF9787      ctermbg=bg  ctermfg=210
+hi Statement   guibg=bg    guifg=#FF9787      ctermbg=bg  ctermfg=210
 
-hi Conditional guibg=bg    guifg=#FF9787      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#FF9787      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#FF9787      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#FF9787      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#FF9787      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#FF9787      ctermbg=bg  ctermfg=210
+hi Repeat      guibg=bg    guifg=#FF9787      ctermbg=bg   ctermfg=210
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#FF9787      ctermbg=bg   ctermfg=210
+hi Keyword     guibg=bg    guifg=#FF9787      ctermbg=bg  ctermfg=210
+hi Exception   guibg=bg    guifg=#FF9787      ctermbg=bg  ctermfg=210
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#e9c865   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#e9c865   ctermbg=bg ctermfg=185
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#e9c865      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#FF9787      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#e9c865    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#e9c865      ctermbg=bg  ctermfg=185
+hi StorageClass   guibg=bg   guifg=#FF9787      ctermbg=bg  ctermfg=210
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#e9c865    ctermbg=bg  ctermfg=185
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#e3d7d6    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#e3d7d6    ctermbg=59   ctermfg=188
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/otakon.vim
+++ b/vim/colors/otakon.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#171417  guifg=#f9f3f9    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#f9f3f9   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#171417  guifg=#f9f3f9    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#f9f3f9   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#B1A6CA   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#B1A6CA   ctermbg=bg ctermfg=146
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#515166  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#515166  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#9eb2d9    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#F6E6EB      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#9eb2d9      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#9eb2d9  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#9eb2d9      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#9eb2d9    ctermbg=bg  ctermfg=146
+hi Character   guibg=bg    guifg=#F6E6EB      ctermbg=bg  ctermfg=225
+hi Number      guibg=bg    guifg=#9eb2d9      ctermbg=bg   ctermfg=146
+hi Boolean     guibg=bg    guifg=#9eb2d9  gui=none    ctermbg=bg   ctermfg=146
+hi Float       guibg=bg    guifg=#9eb2d9      ctermbg=bg   ctermfg=146
 
-hi Identifier  guibg=bg    guifg=#f9f3f9      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#F6E6EB      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#F6E6EB      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#f9f3f9      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#F6E6EB      ctermbg=bg  ctermfg=225
+hi Statement   guibg=bg    guifg=#F6E6EB      ctermbg=bg  ctermfg=225
 
-hi Conditional guibg=bg    guifg=#CACBDD      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#CACBDD      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#CACBDD      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#CACBDD      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#F6E6EB      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#CACBDD      ctermbg=bg  ctermfg=188
+hi Repeat      guibg=bg    guifg=#CACBDD      ctermbg=bg   ctermfg=188
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#CACBDD      ctermbg=bg   ctermfg=188
+hi Keyword     guibg=bg    guifg=#CACBDD      ctermbg=bg  ctermfg=188
+hi Exception   guibg=bg    guifg=#F6E6EB      ctermbg=bg  ctermfg=225
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#B1A6CA   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#B1A6CA   ctermbg=bg ctermfg=146
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#B1A6CA      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#F6E6EB      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#f9f3f9      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#B1A6CA    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#B1A6CA      ctermbg=bg  ctermfg=146
+hi StorageClass   guibg=bg   guifg=#F6E6EB      ctermbg=bg  ctermfg=225
+hi Structure      guibg=bg   guifg=#f9f3f9      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#B1A6CA    ctermbg=bg  ctermfg=146
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#686883    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#686883    ctermbg=59   ctermfg=60
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#f9f3f9        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#f9f3f9        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/pastel.vim
+++ b/vim/colors/pastel.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#222222  guifg=#eeeeee    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#eeeeee   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#222222  guifg=#eeeeee    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#eeeeee   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#9474a9   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#9474a9   ctermbg=bg ctermfg=103
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#444444  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#444444  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#C56C6C    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#04C4A5      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#C56C6C      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#C56C6C  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#C56C6C      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#C56C6C    ctermbg=bg  ctermfg=167
+hi Character   guibg=bg    guifg=#04C4A5      ctermbg=bg  ctermfg=43
+hi Number      guibg=bg    guifg=#C56C6C      ctermbg=bg   ctermfg=167
+hi Boolean     guibg=bg    guifg=#C56C6C  gui=none    ctermbg=bg   ctermfg=167
+hi Float       guibg=bg    guifg=#C56C6C      ctermbg=bg   ctermfg=167
 
-hi Identifier  guibg=bg    guifg=#eeeeee      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#04C4A5      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#04C4A5      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#eeeeee      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#04C4A5      ctermbg=bg  ctermfg=43
+hi Statement   guibg=bg    guifg=#04C4A5      ctermbg=bg  ctermfg=43
 
-hi Conditional guibg=bg    guifg=#C5906C      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#C5906C      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#C5906C      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#C5906C      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#04C4A5      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#C5906C      ctermbg=bg  ctermfg=173
+hi Repeat      guibg=bg    guifg=#C5906C      ctermbg=bg   ctermfg=173
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#C5906C      ctermbg=bg   ctermfg=173
+hi Keyword     guibg=bg    guifg=#C5906C      ctermbg=bg  ctermfg=173
+hi Exception   guibg=bg    guifg=#04C4A5      ctermbg=bg  ctermfg=43
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#9474a9   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#9474a9   ctermbg=bg ctermfg=103
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#9474a9      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#04C4A5      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#eeeeee      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#9474a9    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#9474a9      ctermbg=bg  ctermfg=103
+hi StorageClass   guibg=bg   guifg=#04C4A5      ctermbg=bg  ctermfg=43
+hi Structure      guibg=bg   guifg=#eeeeee      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#9474a9    ctermbg=bg  ctermfg=103
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#666666    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#666666    ctermbg=59   ctermfg=59
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#eeeeee        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#eeeeee        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/patriot-contrast.vim
+++ b/vim/colors/patriot-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0d0e0f  guifg=#CAD9E3    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#CAD9E3   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0d0e0f  guifg=#CAD9E3    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#CAD9E3   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#DE333C   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#DE333C   ctermbg=bg ctermfg=167
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#515E66  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#515E66  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#3790DE    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#2E6FD9      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#2E6FD9  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#2E6FD9      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#3790DE    ctermbg=bg  ctermfg=68
+hi Character   guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=26
+hi Number      guibg=bg    guifg=#2E6FD9      ctermbg=bg   ctermfg=26
+hi Boolean     guibg=bg    guifg=#2E6FD9  gui=none    ctermbg=bg   ctermfg=26
+hi Float       guibg=bg    guifg=#2E6FD9      ctermbg=bg   ctermfg=26
 
-hi Identifier  guibg=bg    guifg=#CAD9E3      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#CAD9E3      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=26
+hi Statement   guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=26
 
-hi Conditional guibg=bg    guifg=#BBBCC4      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#BBBCC4      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#BBBCC4      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#BBBCC4      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#BBBCC4      ctermbg=bg  ctermfg=146
+hi Repeat      guibg=bg    guifg=#BBBCC4      ctermbg=bg   ctermfg=146
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#BBBCC4      ctermbg=bg   ctermfg=146
+hi Keyword     guibg=bg    guifg=#BBBCC4      ctermbg=bg  ctermfg=146
+hi Exception   guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=26
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#DE333C   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#DE333C   ctermbg=bg ctermfg=167
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#DE333C      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#2E6FD9      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#CAD9E3      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#DE333C    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#DE333C      ctermbg=bg  ctermfg=167
+hi StorageClass   guibg=bg   guifg=#2E6FD9      ctermbg=bg  ctermfg=26
+hi Structure      guibg=bg   guifg=#CAD9E3      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#DE333C    ctermbg=bg  ctermfg=167
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#798b96    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#798b96    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#CAD9E3        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#CAD9E3        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/patriot.vim
+++ b/vim/colors/patriot.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2D3133  guifg=#CAD9E3    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#CAD9E3   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2D3133  guifg=#CAD9E3    gui=none ctermbg=23 ctermfg=188
+hi NonText     guibg=bg  guifg=#CAD9E3   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#DE333C   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#DE333C   ctermbg=bg ctermfg=167
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#515E66  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#515E66  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#3790DE    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#2E6FD9      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#2E6FD9  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#2E6FD9      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#3790DE    ctermbg=bg  ctermfg=68
+hi Character   guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=26
+hi Number      guibg=bg    guifg=#2E6FD9      ctermbg=bg   ctermfg=26
+hi Boolean     guibg=bg    guifg=#2E6FD9  gui=none    ctermbg=bg   ctermfg=26
+hi Float       guibg=bg    guifg=#2E6FD9      ctermbg=bg   ctermfg=26
 
-hi Identifier  guibg=bg    guifg=#CAD9E3      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#CAD9E3      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=26
+hi Statement   guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=26
 
-hi Conditional guibg=bg    guifg=#BBBCC4      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#BBBCC4      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#BBBCC4      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#BBBCC4      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#BBBCC4      ctermbg=bg  ctermfg=146
+hi Repeat      guibg=bg    guifg=#BBBCC4      ctermbg=bg   ctermfg=146
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#BBBCC4      ctermbg=bg   ctermfg=146
+hi Keyword     guibg=bg    guifg=#BBBCC4      ctermbg=bg  ctermfg=146
+hi Exception   guibg=bg    guifg=#2E6FD9      ctermbg=bg  ctermfg=26
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#DE333C   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#DE333C   ctermbg=bg ctermfg=167
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#DE333C      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#2E6FD9      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#CAD9E3      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#DE333C    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#DE333C      ctermbg=bg  ctermfg=167
+hi StorageClass   guibg=bg   guifg=#2E6FD9      ctermbg=bg  ctermfg=26
+hi Structure      guibg=bg   guifg=#CAD9E3      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#DE333C    ctermbg=bg  ctermfg=167
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#798b96    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#798b96    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#CAD9E3        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#CAD9E3        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/peacock-contrast.vim
+++ b/vim/colors/peacock-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0c0c0b  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0c0c0b  guifg=#ffffff    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#26a6a6   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#26a6a6   ctermbg=bg ctermfg=37
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#555555  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#555555  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#bcd42a    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#bcd42a      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#bcd42a  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#bcd42a      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#bcd42a    ctermbg=bg  ctermfg=148
+hi Character   guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#bcd42a      ctermbg=bg   ctermfg=148
+hi Boolean     guibg=bg    guifg=#bcd42a  gui=none    ctermbg=bg   ctermfg=148
+hi Float       guibg=bg    guifg=#bcd42a      ctermbg=bg   ctermfg=148
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#26A6A6      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#26A6A6      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi Repeat      guibg=bg    guifg=#26A6A6      ctermbg=bg   ctermfg=37
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#26A6A6      ctermbg=bg   ctermfg=37
+hi Keyword     guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi Exception   guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#26a6a6   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#26a6a6   ctermbg=bg ctermfg=37
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#26a6a6      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#ff5d38      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#26a6a6    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#26a6a6      ctermbg=bg  ctermfg=37
+hi StorageClass   guibg=bg   guifg=#ff5d38      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#26a6a6    ctermbg=bg  ctermfg=37
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#888888    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#888888    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/peacock.vim
+++ b/vim/colors/peacock.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2b2a27  guifg=#ede0ce    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ede0ce   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2b2a27  guifg=#ede0ce    gui=none ctermbg=16 ctermfg=224
+hi NonText     guibg=bg  guifg=#ede0ce   ctermbg=bg ctermfg=224
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#26a6a6   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#26a6a6   ctermbg=bg ctermfg=37
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#7a7267  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#7a7267  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#bcd42a    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#bcd42a      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#bcd42a  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#bcd42a      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#bcd42a    ctermbg=bg  ctermfg=148
+hi Character   guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#bcd42a      ctermbg=bg   ctermfg=148
+hi Boolean     guibg=bg    guifg=#bcd42a  gui=none    ctermbg=bg   ctermfg=148
+hi Float       guibg=bg    guifg=#bcd42a      ctermbg=bg   ctermfg=148
 
-hi Identifier  guibg=bg    guifg=#ede0ce      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ede0ce      ctermbg=bg  ctermfg=224
+hi Function    guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#26A6A6      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#26A6A6      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi Repeat      guibg=bg    guifg=#26A6A6      ctermbg=bg   ctermfg=37
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#26A6A6      ctermbg=bg   ctermfg=37
+hi Keyword     guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi Exception   guibg=bg    guifg=#ff5d38      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#26a6a6   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#26a6a6   ctermbg=bg ctermfg=37
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#26a6a6      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#ff5d38      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ede0ce      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#26a6a6    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#26a6a6      ctermbg=bg  ctermfg=37
+hi StorageClass   guibg=bg   guifg=#ff5d38      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#ede0ce      ctermbg=bg  ctermfg=224
+hi Typedef    guibg=bg   guifg=#26a6a6    ctermbg=bg  ctermfg=37
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#b7b1a9    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#b7b1a9    ctermbg=59   ctermfg=145
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ede0ce        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ede0ce        ctermbg=bg   ctermfg=224
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/peacocks-in-space.vim
+++ b/vim/colors/peacocks-in-space.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2b303b  guifg=#dee3ec    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#dee3ec   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2b303b  guifg=#dee3ec    gui=none ctermbg=23 ctermfg=189
+hi NonText     guibg=bg  guifg=#dee3ec   ctermbg=bg ctermfg=189
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#26A6A6   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#26A6A6   ctermbg=bg ctermfg=37
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#6e7a94  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#6e7a94  gui=none    ctermbg=bg   ctermfg=66
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#BCD42A    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#BCD42A      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#BCD42A  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#BCD42A      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#BCD42A    ctermbg=bg  ctermfg=148
+hi Character   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#BCD42A      ctermbg=bg   ctermfg=148
+hi Boolean     guibg=bg    guifg=#BCD42A  gui=none    ctermbg=bg   ctermfg=148
+hi Float       guibg=bg    guifg=#BCD42A      ctermbg=bg   ctermfg=148
 
-hi Identifier  guibg=bg    guifg=#dee3ec      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#dee3ec      ctermbg=bg  ctermfg=189
+hi Function    guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#26A6A6      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#26A6A6      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi Repeat      guibg=bg    guifg=#26A6A6      ctermbg=bg   ctermfg=37
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#26A6A6      ctermbg=bg   ctermfg=37
+hi Keyword     guibg=bg    guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi Exception   guibg=bg    guifg=#FF5D38      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#26A6A6   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#26A6A6   ctermbg=bg ctermfg=37
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#26A6A6      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#FF5D38      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#dee3ec      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#26A6A6    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#26A6A6      ctermbg=bg  ctermfg=37
+hi StorageClass   guibg=bg   guifg=#FF5D38      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#dee3ec      ctermbg=bg  ctermfg=189
+hi Typedef    guibg=bg   guifg=#26A6A6    ctermbg=bg  ctermfg=37
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#8998b9    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#8998b9    ctermbg=59   ctermfg=103
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#dee3ec        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#dee3ec        ctermbg=bg   ctermfg=189
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/peel.vim
+++ b/vim/colors/peel.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#23201c  guifg=#EDEBE6    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#EDEBE6   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#23201c  guifg=#EDEBE6    gui=none ctermbg=16 ctermfg=230
+hi NonText     guibg=bg  guifg=#EDEBE6   ctermbg=bg ctermfg=230
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#94C7B6   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#94C7B6   ctermbg=bg ctermfg=115
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#585146  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#585146  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#f4d370    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#D3643B      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#f4d370      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#f4d370  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#f4d370      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#f4d370    ctermbg=bg  ctermfg=221
+hi Character   guibg=bg    guifg=#D3643B      ctermbg=bg  ctermfg=167
+hi Number      guibg=bg    guifg=#f4d370      ctermbg=bg   ctermfg=221
+hi Boolean     guibg=bg    guifg=#f4d370  gui=none    ctermbg=bg   ctermfg=221
+hi Float       guibg=bg    guifg=#f4d370      ctermbg=bg   ctermfg=221
 
-hi Identifier  guibg=bg    guifg=#EDEBE6      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#D3643B      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#D3643B      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#EDEBE6      ctermbg=bg  ctermfg=230
+hi Function    guibg=bg    guifg=#D3643B      ctermbg=bg  ctermfg=167
+hi Statement   guibg=bg    guifg=#D3643B      ctermbg=bg  ctermfg=167
 
-hi Conditional guibg=bg    guifg=#94C7B6      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#94C7B6      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#94C7B6      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#94C7B6      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#D3643B      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#94C7B6      ctermbg=bg  ctermfg=115
+hi Repeat      guibg=bg    guifg=#94C7B6      ctermbg=bg   ctermfg=115
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#94C7B6      ctermbg=bg   ctermfg=115
+hi Keyword     guibg=bg    guifg=#94C7B6      ctermbg=bg  ctermfg=115
+hi Exception   guibg=bg    guifg=#D3643B      ctermbg=bg  ctermfg=167
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#94C7B6   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#94C7B6   ctermbg=bg ctermfg=115
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#94C7B6      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#D3643B      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#EDEBE6      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#94C7B6    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#94C7B6      ctermbg=bg  ctermfg=115
+hi StorageClass   guibg=bg   guifg=#D3643B      ctermbg=bg  ctermfg=167
+hi Structure      guibg=bg   guifg=#EDEBE6      ctermbg=bg  ctermfg=230
+hi Typedef    guibg=bg   guifg=#94C7B6    ctermbg=bg  ctermfg=115
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#827766    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#827766    ctermbg=59   ctermfg=101
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#EDEBE6        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#EDEBE6        ctermbg=bg   ctermfg=230
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/piggy.vim
+++ b/vim/colors/piggy.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#1c1618  guifg=#EDEBE6    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#EDEBE6   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#1c1618  guifg=#EDEBE6    gui=none ctermbg=16 ctermfg=230
+hi NonText     guibg=bg  guifg=#EDEBE6   ctermbg=bg ctermfg=230
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#F52E62   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#F52E62   ctermbg=bg ctermfg=197
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#3f3236  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#3f3236  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#FF453E    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#FD6A5D      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#FF453E      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#FF453E  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#FF453E      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#FF453E    ctermbg=bg  ctermfg=203
+hi Character   guibg=bg    guifg=#FD6A5D      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#FF453E      ctermbg=bg   ctermfg=203
+hi Boolean     guibg=bg    guifg=#FF453E  gui=none    ctermbg=bg   ctermfg=203
+hi Float       guibg=bg    guifg=#FF453E      ctermbg=bg   ctermfg=203
 
-hi Identifier  guibg=bg    guifg=#EDEBE6      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#FD6A5D      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#FD6A5D      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#EDEBE6      ctermbg=bg  ctermfg=230
+hi Function    guibg=bg    guifg=#FD6A5D      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#FD6A5D      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#FD6A5D      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#FD6A5D      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#FD6A5D      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#FD6A5D      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#FD6A5D      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#FD6A5D      ctermbg=bg  ctermfg=203
+hi Repeat      guibg=bg    guifg=#FD6A5D      ctermbg=bg   ctermfg=203
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#FD6A5D      ctermbg=bg   ctermfg=203
+hi Keyword     guibg=bg    guifg=#FD6A5D      ctermbg=bg  ctermfg=203
+hi Exception   guibg=bg    guifg=#FD6A5D      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#F52E62   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#F52E62   ctermbg=bg ctermfg=197
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#F52E62      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#FD6A5D      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#EDEBE6      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#F52E62    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#F52E62      ctermbg=bg  ctermfg=197
+hi StorageClass   guibg=bg   guifg=#FD6A5D      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#EDEBE6      ctermbg=bg  ctermfg=230
+hi Typedef    guibg=bg   guifg=#F52E62    ctermbg=bg  ctermfg=197
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#6a515a    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#6a515a    ctermbg=59   ctermfg=59
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#EDEBE6        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#EDEBE6        ctermbg=bg   ctermfg=230
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/potpourri-contrast.vim
+++ b/vim/colors/potpourri-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0d0c0c  guifg=#F8F8F2    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0d0c0c  guifg=#F8F8F2    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#C491C4   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#C491C4   ctermbg=bg ctermfg=176
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#696363  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#696363  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#B866FA    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#C84FF0      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#C84FF0  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#C84FF0      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#B866FA    ctermbg=bg  ctermfg=135
+hi Character   guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=197
+hi Number      guibg=bg    guifg=#C84FF0      ctermbg=bg   ctermfg=171
+hi Boolean     guibg=bg    guifg=#C84FF0  gui=none    ctermbg=bg   ctermfg=171
+hi Float       guibg=bg    guifg=#C84FF0      ctermbg=bg   ctermfg=171
 
-hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=197
+hi Statement   guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=197
 
-hi Conditional guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#ED1153      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#ED1153      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=197
+hi Repeat      guibg=bg    guifg=#ED1153      ctermbg=bg   ctermfg=197
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#ED1153      ctermbg=bg   ctermfg=197
+hi Keyword     guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=197
+hi Exception   guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=197
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#C491C4   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#C491C4   ctermbg=bg ctermfg=176
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#C491C4      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#ED1153      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#C491C4    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#C491C4      ctermbg=bg  ctermfg=176
+hi StorageClass   guibg=bg   guifg=#ED1153      ctermbg=bg  ctermfg=197
+hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#C491C4    ctermbg=bg  ctermfg=176
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#8f8787    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#8f8787    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/potpourri.vim
+++ b/vim/colors/potpourri.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2E2B2C  guifg=#F8F8F2    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2E2B2C  guifg=#F8F8F2    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#F8F8F2   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#C491C4   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#C491C4   ctermbg=bg ctermfg=176
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#696363  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#696363  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#B866FA    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#C84FF0      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#C84FF0  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#C84FF0      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#B866FA    ctermbg=bg  ctermfg=135
+hi Character   guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=197
+hi Number      guibg=bg    guifg=#C84FF0      ctermbg=bg   ctermfg=171
+hi Boolean     guibg=bg    guifg=#C84FF0  gui=none    ctermbg=bg   ctermfg=171
+hi Float       guibg=bg    guifg=#C84FF0      ctermbg=bg   ctermfg=171
 
-hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=197
+hi Statement   guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=197
 
-hi Conditional guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#ED1153      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#ED1153      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=197
+hi Repeat      guibg=bg    guifg=#ED1153      ctermbg=bg   ctermfg=197
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#ED1153      ctermbg=bg   ctermfg=197
+hi Keyword     guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=197
+hi Exception   guibg=bg    guifg=#ED1153      ctermbg=bg  ctermfg=197
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#C491C4   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#C491C4   ctermbg=bg ctermfg=176
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#C491C4      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#ED1153      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#C491C4    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#C491C4      ctermbg=bg  ctermfg=176
+hi StorageClass   guibg=bg   guifg=#ED1153      ctermbg=bg  ctermfg=197
+hi Structure      guibg=bg   guifg=#F8F8F2      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#C491C4    ctermbg=bg  ctermfg=176
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#8f8787    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#8f8787    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#F8F8F2        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/rainbow.vim
+++ b/vim/colors/rainbow.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#16181a  guifg=#c7d0d9    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#c7d0d9   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#16181a  guifg=#c7d0d9    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#c7d0d9   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#B3CC57   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#B3CC57   ctermbg=bg ctermfg=149
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#424c55  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#424c55  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#c78feb    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#EF746F      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#c78feb      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#c78feb  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#c78feb      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#c78feb    ctermbg=bg  ctermfg=177
+hi Character   guibg=bg    guifg=#EF746F      ctermbg=bg  ctermfg=209
+hi Number      guibg=bg    guifg=#c78feb      ctermbg=bg   ctermfg=177
+hi Boolean     guibg=bg    guifg=#c78feb  gui=none    ctermbg=bg   ctermfg=177
+hi Float       guibg=bg    guifg=#c78feb      ctermbg=bg   ctermfg=177
 
-hi Identifier  guibg=bg    guifg=#c7d0d9      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#EF746F      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#EF746F      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#c7d0d9      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#EF746F      ctermbg=bg  ctermfg=209
+hi Statement   guibg=bg    guifg=#EF746F      ctermbg=bg  ctermfg=209
 
-hi Conditional guibg=bg    guifg=#3fb4c5      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#3fb4c5      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#3fb4c5      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#3fb4c5      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#EF746F      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#3fb4c5      ctermbg=bg  ctermfg=74
+hi Repeat      guibg=bg    guifg=#3fb4c5      ctermbg=bg   ctermfg=74
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#3fb4c5      ctermbg=bg   ctermfg=74
+hi Keyword     guibg=bg    guifg=#3fb4c5      ctermbg=bg  ctermfg=74
+hi Exception   guibg=bg    guifg=#EF746F      ctermbg=bg  ctermfg=209
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#B3CC57   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#B3CC57   ctermbg=bg ctermfg=149
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#B3CC57      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#EF746F      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#c7d0d9      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#B3CC57    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#B3CC57      ctermbg=bg  ctermfg=149
+hi StorageClass   guibg=bg   guifg=#EF746F      ctermbg=bg  ctermfg=209
+hi Structure      guibg=bg   guifg=#c7d0d9      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#B3CC57    ctermbg=bg  ctermfg=149
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#5f6f7f    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#5f6f7f    ctermbg=59   ctermfg=60
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#c7d0d9        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#c7d0d9        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/revelation-contrast.vim
+++ b/vim/colors/revelation-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0c0b0b  guifg=#DEDEDE    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0c0b0b  guifg=#DEDEDE    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#4E5D84   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#4E5D84   ctermbg=bg ctermfg=60
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#7b726b  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#7b726b  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#FFBB29    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#617FA0      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#617FA0  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#617FA0      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#FFBB29    ctermbg=bg  ctermfg=214
+hi Character   guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=67
+hi Number      guibg=bg    guifg=#617FA0      ctermbg=bg   ctermfg=67
+hi Boolean     guibg=bg    guifg=#617FA0  gui=none    ctermbg=bg   ctermfg=67
+hi Float       guibg=bg    guifg=#617FA0      ctermbg=bg   ctermfg=67
 
-hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=67
+hi Statement   guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=67
 
-hi Conditional guibg=bg    guifg=#C2DCF2      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#C2DCF2      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#C2DCF2      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#C2DCF2      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#C2DCF2      ctermbg=bg  ctermfg=153
+hi Repeat      guibg=bg    guifg=#C2DCF2      ctermbg=bg   ctermfg=153
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#C2DCF2      ctermbg=bg   ctermfg=153
+hi Keyword     guibg=bg    guifg=#C2DCF2      ctermbg=bg  ctermfg=153
+hi Exception   guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=67
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#4E5D84   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#4E5D84   ctermbg=bg ctermfg=60
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#4E5D84      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#617FA0      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#4E5D84    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#4E5D84      ctermbg=bg  ctermfg=60
+hi StorageClass   guibg=bg   guifg=#617FA0      ctermbg=bg  ctermfg=67
+hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#4E5D84    ctermbg=bg  ctermfg=60
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#a19790    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#a19790    ctermbg=59   ctermfg=138
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/revelation.vim
+++ b/vim/colors/revelation.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2E2C2B  guifg=#DEDEDE    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2E2C2B  guifg=#DEDEDE    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#4E5D84   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#4E5D84   ctermbg=bg ctermfg=60
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#7b726b  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#7b726b  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#FFBB29    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#617FA0      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#617FA0  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#617FA0      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#FFBB29    ctermbg=bg  ctermfg=214
+hi Character   guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=67
+hi Number      guibg=bg    guifg=#617FA0      ctermbg=bg   ctermfg=67
+hi Boolean     guibg=bg    guifg=#617FA0  gui=none    ctermbg=bg   ctermfg=67
+hi Float       guibg=bg    guifg=#617FA0      ctermbg=bg   ctermfg=67
 
-hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=67
+hi Statement   guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=67
 
-hi Conditional guibg=bg    guifg=#C2DCF2      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#C2DCF2      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#C2DCF2      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#C2DCF2      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#C2DCF2      ctermbg=bg  ctermfg=153
+hi Repeat      guibg=bg    guifg=#C2DCF2      ctermbg=bg   ctermfg=153
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#C2DCF2      ctermbg=bg   ctermfg=153
+hi Keyword     guibg=bg    guifg=#C2DCF2      ctermbg=bg  ctermfg=153
+hi Exception   guibg=bg    guifg=#617FA0      ctermbg=bg  ctermfg=67
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#4E5D84   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#4E5D84   ctermbg=bg ctermfg=60
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#4E5D84      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#617FA0      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#4E5D84    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#4E5D84      ctermbg=bg  ctermfg=60
+hi StorageClass   guibg=bg   guifg=#617FA0      ctermbg=bg  ctermfg=67
+hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#4E5D84    ctermbg=bg  ctermfg=60
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#a19790    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#a19790    ctermbg=59   ctermfg=138
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/shrek.vim
+++ b/vim/colors/shrek.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#222222  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#222222  guifg=#ffffff    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#B2DE62   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#B2DE62   ctermbg=bg ctermfg=149
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#555555  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#555555  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#81e911    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#857a5e      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#81e911      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#81e911  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#81e911      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#81e911    ctermbg=bg  ctermfg=112
+hi Character   guibg=bg    guifg=#857a5e      ctermbg=bg  ctermfg=101
+hi Number      guibg=bg    guifg=#81e911      ctermbg=bg   ctermfg=112
+hi Boolean     guibg=bg    guifg=#81e911  gui=none    ctermbg=bg   ctermfg=112
+hi Float       guibg=bg    guifg=#81e911      ctermbg=bg   ctermfg=112
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#857a5e      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#857a5e      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#857a5e      ctermbg=bg  ctermfg=101
+hi Statement   guibg=bg    guifg=#857a5e      ctermbg=bg  ctermfg=101
 
-hi Conditional guibg=bg    guifg=#bfb59b      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#bfb59b      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#bfb59b      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#bfb59b      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#857a5e      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#bfb59b      ctermbg=bg  ctermfg=145
+hi Repeat      guibg=bg    guifg=#bfb59b      ctermbg=bg   ctermfg=145
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#bfb59b      ctermbg=bg   ctermfg=145
+hi Keyword     guibg=bg    guifg=#bfb59b      ctermbg=bg  ctermfg=145
+hi Exception   guibg=bg    guifg=#857a5e      ctermbg=bg  ctermfg=101
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#B2DE62   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#B2DE62   ctermbg=bg ctermfg=149
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#B2DE62      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#857a5e      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#B2DE62    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#B2DE62      ctermbg=bg  ctermfg=149
+hi StorageClass   guibg=bg   guifg=#857a5e      ctermbg=bg  ctermfg=101
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#B2DE62    ctermbg=bg  ctermfg=149
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#777777    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#777777    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/slate.vim
+++ b/vim/colors/slate.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#19191f  guifg=#ebebf4    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ebebf4   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#19191f  guifg=#ebebf4    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ebebf4   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#566981   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#566981   ctermbg=bg ctermfg=60
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#515166  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#515166  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#9eb2d9    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#89A7B1      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#9eb2d9      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#9eb2d9  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#9eb2d9      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#9eb2d9    ctermbg=bg  ctermfg=146
+hi Character   guibg=bg    guifg=#89A7B1      ctermbg=bg  ctermfg=109
+hi Number      guibg=bg    guifg=#9eb2d9      ctermbg=bg   ctermfg=146
+hi Boolean     guibg=bg    guifg=#9eb2d9  gui=none    ctermbg=bg   ctermfg=146
+hi Float       guibg=bg    guifg=#9eb2d9      ctermbg=bg   ctermfg=146
 
-hi Identifier  guibg=bg    guifg=#ebebf4      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#89A7B1      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#89A7B1      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ebebf4      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#89A7B1      ctermbg=bg  ctermfg=109
+hi Statement   guibg=bg    guifg=#89A7B1      ctermbg=bg  ctermfg=109
 
-hi Conditional guibg=bg    guifg=#566981      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#566981      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#566981      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#566981      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#89A7B1      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#566981      ctermbg=bg  ctermfg=60
+hi Repeat      guibg=bg    guifg=#566981      ctermbg=bg   ctermfg=60
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#566981      ctermbg=bg   ctermfg=60
+hi Keyword     guibg=bg    guifg=#566981      ctermbg=bg  ctermfg=60
+hi Exception   guibg=bg    guifg=#89A7B1      ctermbg=bg  ctermfg=109
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#566981   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#566981   ctermbg=bg ctermfg=60
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#566981      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#89A7B1      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ebebf4      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#566981    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#566981      ctermbg=bg  ctermfg=60
+hi StorageClass   guibg=bg   guifg=#89A7B1      ctermbg=bg  ctermfg=109
+hi Structure      guibg=bg   guifg=#ebebf4      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#566981    ctermbg=bg  ctermfg=60
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#686883    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#686883    ctermbg=59   ctermfg=60
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ebebf4        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ebebf4        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/slime-contrast.vim
+++ b/vim/colors/slime-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0b0c0d  guifg=#FFFFFF    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#FFFFFF   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0b0c0d  guifg=#FFFFFF    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#FFFFFF   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#d8e778   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#d8e778   ctermbg=bg ctermfg=186
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#4F5A63  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#4F5A63  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#FAFFDB    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#6a9ec5      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#C7AF3F      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#C7AF3F  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#C7AF3F      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#FAFFDB    ctermbg=bg  ctermfg=230
+hi Character   guibg=bg    guifg=#6a9ec5      ctermbg=bg  ctermfg=74
+hi Number      guibg=bg    guifg=#C7AF3F      ctermbg=bg   ctermfg=179
+hi Boolean     guibg=bg    guifg=#C7AF3F  gui=none    ctermbg=bg   ctermfg=179
+hi Float       guibg=bg    guifg=#C7AF3F      ctermbg=bg   ctermfg=179
 
-hi Identifier  guibg=bg    guifg=#FFFFFF      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#6a9ec5      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#6a9ec5      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#FFFFFF      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#6a9ec5      ctermbg=bg  ctermfg=74
+hi Statement   guibg=bg    guifg=#6a9ec5      ctermbg=bg  ctermfg=74
 
-hi Conditional guibg=bg    guifg=#689dc5      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#689dc5      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#689dc5      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#689dc5      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#6a9ec5      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#689dc5      ctermbg=bg  ctermfg=74
+hi Repeat      guibg=bg    guifg=#689dc5      ctermbg=bg   ctermfg=74
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#689dc5      ctermbg=bg   ctermfg=74
+hi Keyword     guibg=bg    guifg=#689dc5      ctermbg=bg  ctermfg=74
+hi Exception   guibg=bg    guifg=#6a9ec5      ctermbg=bg  ctermfg=74
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#d8e778   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#d8e778   ctermbg=bg ctermfg=186
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#d8e778      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#6a9ec5      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#FFFFFF      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#d8e778    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#d8e778      ctermbg=bg  ctermfg=186
+hi StorageClass   guibg=bg   guifg=#6a9ec5      ctermbg=bg  ctermfg=74
+hi Structure      guibg=bg   guifg=#FFFFFF      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#d8e778    ctermbg=bg  ctermfg=186
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#80919f    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#80919f    ctermbg=59   ctermfg=103
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#FFFFFF        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#FFFFFF        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/slime.vim
+++ b/vim/colors/slime.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#292D30  guifg=#FFFFFF    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#FFFFFF   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#292D30  guifg=#FFFFFF    gui=none ctermbg=17 ctermfg=231
+hi NonText     guibg=bg  guifg=#FFFFFF   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#FAFFDB   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#FAFFDB   ctermbg=bg ctermfg=230
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#4F5A63  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#4F5A63  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#FAFFDB    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#9FB3C2      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#C7AF3F      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#C7AF3F  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#C7AF3F      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#FAFFDB    ctermbg=bg  ctermfg=230
+hi Character   guibg=bg    guifg=#9FB3C2      ctermbg=bg  ctermfg=145
+hi Number      guibg=bg    guifg=#C7AF3F      ctermbg=bg   ctermfg=179
+hi Boolean     guibg=bg    guifg=#C7AF3F  gui=none    ctermbg=bg   ctermfg=179
+hi Float       guibg=bg    guifg=#C7AF3F      ctermbg=bg   ctermfg=179
 
-hi Identifier  guibg=bg    guifg=#FFFFFF      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#9FB3C2      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#9FB3C2      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#FFFFFF      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#9FB3C2      ctermbg=bg  ctermfg=145
+hi Statement   guibg=bg    guifg=#9FB3C2      ctermbg=bg  ctermfg=145
 
-hi Conditional guibg=bg    guifg=#9FB3C2      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#9FB3C2      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#9FB3C2      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#9FB3C2      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#9FB3C2      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#9FB3C2      ctermbg=bg  ctermfg=145
+hi Repeat      guibg=bg    guifg=#9FB3C2      ctermbg=bg   ctermfg=145
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#9FB3C2      ctermbg=bg   ctermfg=145
+hi Keyword     guibg=bg    guifg=#9FB3C2      ctermbg=bg  ctermfg=145
+hi Exception   guibg=bg    guifg=#9FB3C2      ctermbg=bg  ctermfg=145
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#FAFFDB   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#FAFFDB   ctermbg=bg ctermfg=230
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#FAFFDB      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#9FB3C2      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#FFFFFF      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#FAFFDB    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#FAFFDB      ctermbg=bg  ctermfg=230
+hi StorageClass   guibg=bg   guifg=#9FB3C2      ctermbg=bg  ctermfg=145
+hi Structure      guibg=bg   guifg=#FFFFFF      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#FAFFDB    ctermbg=bg  ctermfg=230
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#80919f    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#80919f    ctermbg=59   ctermfg=103
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#FFFFFF        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#FFFFFF        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/snappy-contrast.vim
+++ b/vim/colors/snappy-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0c0c0c  guifg=#e3e2e0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#e3e2e0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0c0c0c  guifg=#e3e2e0    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#e3e2e0   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#4ea1df   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#4ea1df   ctermbg=bg ctermfg=74
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#696969  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#696969  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#4ea1df    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#4ea1df      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#4ea1df  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#4ea1df      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#4ea1df    ctermbg=bg  ctermfg=74
+hi Character   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#4ea1df      ctermbg=bg   ctermfg=74
+hi Boolean     guibg=bg    guifg=#4ea1df  gui=none    ctermbg=bg   ctermfg=74
+hi Float       guibg=bg    guifg=#4ea1df      ctermbg=bg   ctermfg=74
 
-hi Identifier  guibg=bg    guifg=#e3e2e0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#e3e2e0      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#f66153      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#f66153      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Repeat      guibg=bg    guifg=#f66153      ctermbg=bg   ctermfg=203
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#f66153      ctermbg=bg   ctermfg=203
+hi Keyword     guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Exception   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#4ea1df   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#4ea1df   ctermbg=bg ctermfg=74
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#4ea1df      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#f66153      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#e3e2e0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#4ea1df    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#4ea1df      ctermbg=bg  ctermfg=74
+hi StorageClass   guibg=bg   guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#e3e2e0      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#4ea1df    ctermbg=bg  ctermfg=74
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#909090    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#909090    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#e3e2e0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#e3e2e0        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/snappy-light.vim
+++ b/vim/colors/snappy-light.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#ffffff  guifg=#555555    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#555555   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#ffffff  guifg=#555555    gui=none ctermbg=231 ctermfg=59
+hi NonText     guibg=bg  guifg=#555555   ctermbg=bg ctermfg=59
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#4ea1df   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#4ea1df   ctermbg=bg ctermfg=74
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#bbbbbb  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#bbbbbb  gui=none    ctermbg=bg   ctermfg=145
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#4ea1df    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#4ea1df      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#4ea1df  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#4ea1df      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#4ea1df    ctermbg=bg  ctermfg=74
+hi Character   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#4ea1df      ctermbg=bg   ctermfg=74
+hi Boolean     guibg=bg    guifg=#4ea1df  gui=none    ctermbg=bg   ctermfg=74
+hi Float       guibg=bg    guifg=#4ea1df      ctermbg=bg   ctermfg=74
 
-hi Identifier  guibg=bg    guifg=#555555      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#555555      ctermbg=bg  ctermfg=59
+hi Function    guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#da564a      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#da564a      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#da564a      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#da564a      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#da564a      ctermbg=bg  ctermfg=167
+hi Repeat      guibg=bg    guifg=#da564a      ctermbg=bg   ctermfg=167
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#da564a      ctermbg=bg   ctermfg=167
+hi Keyword     guibg=bg    guifg=#da564a      ctermbg=bg  ctermfg=167
+hi Exception   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#4ea1df   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#4ea1df   ctermbg=bg ctermfg=74
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#4ea1df      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#f66153      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#555555      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#4ea1df    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#4ea1df      ctermbg=bg  ctermfg=74
+hi StorageClass   guibg=bg   guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#555555      ctermbg=bg  ctermfg=59
+hi Typedef    guibg=bg   guifg=#4ea1df    ctermbg=bg  ctermfg=74
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#7d7d7d    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#7d7d7d    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#555555        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#555555        ctermbg=bg   ctermfg=59
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/snappy.vim
+++ b/vim/colors/snappy.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#393939  guifg=#e3e2e0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#e3e2e0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#393939  guifg=#e3e2e0    gui=none ctermbg=59 ctermfg=188
+hi NonText     guibg=bg  guifg=#e3e2e0   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#4ea1df   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#4ea1df   ctermbg=bg ctermfg=74
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#696969  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#696969  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#4ea1df    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#4ea1df      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#4ea1df  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#4ea1df      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#4ea1df    ctermbg=bg  ctermfg=74
+hi Character   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#4ea1df      ctermbg=bg   ctermfg=74
+hi Boolean     guibg=bg    guifg=#4ea1df  gui=none    ctermbg=bg   ctermfg=74
+hi Float       guibg=bg    guifg=#4ea1df      ctermbg=bg   ctermfg=74
 
-hi Identifier  guibg=bg    guifg=#e3e2e0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#e3e2e0      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#f66153      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#f66153      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Repeat      guibg=bg    guifg=#f66153      ctermbg=bg   ctermfg=203
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#f66153      ctermbg=bg   ctermfg=203
+hi Keyword     guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Exception   guibg=bg    guifg=#f66153      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#4ea1df   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#4ea1df   ctermbg=bg ctermfg=74
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#4ea1df      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#f66153      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#e3e2e0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#4ea1df    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#4ea1df      ctermbg=bg  ctermfg=74
+hi StorageClass   guibg=bg   guifg=#f66153      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#e3e2e0      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#4ea1df    ctermbg=bg  ctermfg=74
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#909090    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#909090    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#e3e2e0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#e3e2e0        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/solarflare-contrast.vim
+++ b/vim/colors/solarflare-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#000000  guifg=#e3e2e0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#e3e2e0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#000000  guifg=#e3e2e0    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#e3e2e0   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#FC913A   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#FC913A   ctermbg=bg ctermfg=209
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#777777  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#777777  gui=none    ctermbg=bg   ctermfg=102
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#EDE574    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#FF4E50      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#FF4E50  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#FF4E50      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#EDE574    ctermbg=bg  ctermfg=222
+hi Character   guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#FF4E50      ctermbg=bg   ctermfg=203
+hi Boolean     guibg=bg    guifg=#FF4E50  gui=none    ctermbg=bg   ctermfg=203
+hi Float       guibg=bg    guifg=#FF4E50      ctermbg=bg   ctermfg=203
 
-hi Identifier  guibg=bg    guifg=#e3e2e0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#e3e2e0      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#FF4E50      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#FF4E50      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=203
+hi Repeat      guibg=bg    guifg=#FF4E50      ctermbg=bg   ctermfg=203
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#FF4E50      ctermbg=bg   ctermfg=203
+hi Keyword     guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=203
+hi Exception   guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#FC913A   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#FC913A   ctermbg=bg ctermfg=209
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#FC913A      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#FF4E50      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#e3e2e0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#FC913A    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#FC913A      ctermbg=bg  ctermfg=209
+hi StorageClass   guibg=bg   guifg=#FF4E50      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#e3e2e0      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#FC913A    ctermbg=bg  ctermfg=209
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#9b9b9b    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#9b9b9b    ctermbg=59   ctermfg=145
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#e3e2e0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#e3e2e0        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/solarflare.vim
+++ b/vim/colors/solarflare.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#222222  guifg=#e3e2e0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#e3e2e0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#222222  guifg=#e3e2e0    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#e3e2e0   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#FC913A   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#FC913A   ctermbg=bg ctermfg=209
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#777777  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#777777  gui=none    ctermbg=bg   ctermfg=102
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#EDE574    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#FF4E50      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#FF4E50  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#FF4E50      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#EDE574    ctermbg=bg  ctermfg=222
+hi Character   guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#FF4E50      ctermbg=bg   ctermfg=203
+hi Boolean     guibg=bg    guifg=#FF4E50  gui=none    ctermbg=bg   ctermfg=203
+hi Float       guibg=bg    guifg=#FF4E50      ctermbg=bg   ctermfg=203
 
-hi Identifier  guibg=bg    guifg=#e3e2e0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#e3e2e0      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#FF4E50      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#FF4E50      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=203
+hi Repeat      guibg=bg    guifg=#FF4E50      ctermbg=bg   ctermfg=203
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#FF4E50      ctermbg=bg   ctermfg=203
+hi Keyword     guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=203
+hi Exception   guibg=bg    guifg=#FF4E50      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#FC913A   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#FC913A   ctermbg=bg ctermfg=209
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#FC913A      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#FF4E50      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#e3e2e0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#FC913A    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#FC913A      ctermbg=bg  ctermfg=209
+hi StorageClass   guibg=bg   guifg=#FF4E50      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#e3e2e0      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#FC913A    ctermbg=bg  ctermfg=209
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#9b9b9b    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#9b9b9b    ctermbg=59   ctermfg=145
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#e3e2e0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#e3e2e0        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/sourlick-contrast.vim
+++ b/vim/colors/sourlick-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#060606  guifg=#DEDEDE    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#060606  guifg=#DEDEDE    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#EDF252   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#EDF252   ctermbg=bg ctermfg=227
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#615953  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#615953  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#E4FF33    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#FC580C      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#FC580C  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#FC580C      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#E4FF33    ctermbg=bg  ctermfg=191
+hi Character   guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=108
+hi Number      guibg=bg    guifg=#FC580C      ctermbg=bg   ctermfg=202
+hi Boolean     guibg=bg    guifg=#FC580C  gui=none    ctermbg=bg   ctermfg=202
+hi Float       guibg=bg    guifg=#FC580C      ctermbg=bg   ctermfg=202
 
-hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=108
+hi Statement   guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=108
 
-hi Conditional guibg=bg    guifg=#D2EB31      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#D2EB31      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#D2EB31      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#D2EB31      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#D2EB31      ctermbg=bg  ctermfg=191
+hi Repeat      guibg=bg    guifg=#D2EB31      ctermbg=bg   ctermfg=191
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#D2EB31      ctermbg=bg   ctermfg=191
+hi Keyword     guibg=bg    guifg=#D2EB31      ctermbg=bg  ctermfg=191
+hi Exception   guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=108
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#EDF252   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#EDF252   ctermbg=bg ctermfg=227
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#EDF252      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#8AC27A      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#EDF252    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#EDF252      ctermbg=bg  ctermfg=227
+hi StorageClass   guibg=bg   guifg=#8AC27A      ctermbg=bg  ctermfg=108
+hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#EDF252    ctermbg=bg  ctermfg=227
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#92867d    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#92867d    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/sourlick.vim
+++ b/vim/colors/sourlick.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2E2C2B  guifg=#DEDEDE    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2E2C2B  guifg=#DEDEDE    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#EDF252   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#EDF252   ctermbg=bg ctermfg=227
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#615953  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#615953  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#E4FF33    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#FC580C      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#FC580C  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#FC580C      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#E4FF33    ctermbg=bg  ctermfg=191
+hi Character   guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=108
+hi Number      guibg=bg    guifg=#FC580C      ctermbg=bg   ctermfg=202
+hi Boolean     guibg=bg    guifg=#FC580C  gui=none    ctermbg=bg   ctermfg=202
+hi Float       guibg=bg    guifg=#FC580C      ctermbg=bg   ctermfg=202
 
-hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=108
+hi Statement   guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=108
 
-hi Conditional guibg=bg    guifg=#D2EB31      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#D2EB31      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#D2EB31      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#D2EB31      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#D2EB31      ctermbg=bg  ctermfg=191
+hi Repeat      guibg=bg    guifg=#D2EB31      ctermbg=bg   ctermfg=191
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#D2EB31      ctermbg=bg   ctermfg=191
+hi Keyword     guibg=bg    guifg=#D2EB31      ctermbg=bg  ctermfg=191
+hi Exception   guibg=bg    guifg=#8AC27A      ctermbg=bg  ctermfg=108
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#EDF252   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#EDF252   ctermbg=bg ctermfg=227
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#EDF252      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#8AC27A      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#EDF252    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#EDF252      ctermbg=bg  ctermfg=227
+hi StorageClass   guibg=bg   guifg=#8AC27A      ctermbg=bg  ctermfg=108
+hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#EDF252    ctermbg=bg  ctermfg=227
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#92867d    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#92867d    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/spearmint.vim
+++ b/vim/colors/spearmint.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#E1F0EE  guifg=#719692    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#719692   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#E1F0EE  guifg=#719692    gui=none ctermbg=195 ctermfg=66
+hi NonText     guibg=bg  guifg=#719692   ctermbg=bg ctermfg=66
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#69ADB5   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#69ADB5   ctermbg=bg ctermfg=73
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#93C7C0  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#93C7C0  gui=none    ctermbg=bg   ctermfg=115
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#4CD7E0    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#25808A      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#199FA8      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#199FA8  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#199FA8      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#4CD7E0    ctermbg=bg  ctermfg=80
+hi Character   guibg=bg    guifg=#25808A      ctermbg=bg  ctermfg=30
+hi Number      guibg=bg    guifg=#199FA8      ctermbg=bg   ctermfg=37
+hi Boolean     guibg=bg    guifg=#199FA8  gui=none    ctermbg=bg   ctermfg=37
+hi Float       guibg=bg    guifg=#199FA8      ctermbg=bg   ctermfg=37
 
-hi Identifier  guibg=bg    guifg=#719692      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#25808A      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#25808A      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#719692      ctermbg=bg  ctermfg=66
+hi Function    guibg=bg    guifg=#25808A      ctermbg=bg  ctermfg=30
+hi Statement   guibg=bg    guifg=#25808A      ctermbg=bg  ctermfg=30
 
-hi Conditional guibg=bg    guifg=#69ADB5      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#69ADB5      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#69ADB5      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#69ADB5      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#25808A      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#69ADB5      ctermbg=bg  ctermfg=73
+hi Repeat      guibg=bg    guifg=#69ADB5      ctermbg=bg   ctermfg=73
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#69ADB5      ctermbg=bg   ctermfg=73
+hi Keyword     guibg=bg    guifg=#69ADB5      ctermbg=bg  ctermfg=73
+hi Exception   guibg=bg    guifg=#25808A      ctermbg=bg  ctermfg=30
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#69ADB5   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#69ADB5   ctermbg=bg ctermfg=73
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#69ADB5      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#25808A      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#719692      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#69ADB5    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#69ADB5      ctermbg=bg  ctermfg=73
+hi StorageClass   guibg=bg   guifg=#25808A      ctermbg=bg  ctermfg=30
+hi Structure      guibg=bg   guifg=#719692      ctermbg=bg  ctermfg=66
+hi Typedef    guibg=bg   guifg=#69ADB5    ctermbg=bg  ctermfg=73
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#729e98    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#729e98    ctermbg=59   ctermfg=72
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#719692        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#719692        ctermbg=bg   ctermfg=66
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/stark-contrast.vim
+++ b/vim/colors/stark-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#0b0a0a  guifg=#DEDEDE    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#0b0a0a  guifg=#DEDEDE    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#FFBB29   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#FFBB29   ctermbg=bg ctermfg=214
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#615953  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#615953  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#FFBB29    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#617FA0      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#617FA0  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#617FA0      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#FFBB29    ctermbg=bg  ctermfg=214
+hi Character   guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=202
+hi Number      guibg=bg    guifg=#617FA0      ctermbg=bg   ctermfg=67
+hi Boolean     guibg=bg    guifg=#617FA0  gui=none    ctermbg=bg   ctermfg=67
+hi Float       guibg=bg    guifg=#617FA0      ctermbg=bg   ctermfg=67
 
-hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=202
+hi Statement   guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=202
 
-hi Conditional guibg=bg    guifg=#aaaaaa      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#aaaaaa      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#aaaaaa      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#aaaaaa      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#aaaaaa      ctermbg=bg  ctermfg=145
+hi Repeat      guibg=bg    guifg=#aaaaaa      ctermbg=bg   ctermfg=145
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#aaaaaa      ctermbg=bg   ctermfg=145
+hi Keyword     guibg=bg    guifg=#aaaaaa      ctermbg=bg  ctermfg=145
+hi Exception   guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=202
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#FFBB29   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#FFBB29   ctermbg=bg ctermfg=214
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#FFBB29      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#F03113      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#FFBB29    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#FFBB29      ctermbg=bg  ctermfg=214
+hi StorageClass   guibg=bg   guifg=#F03113      ctermbg=bg  ctermfg=202
+hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#FFBB29    ctermbg=bg  ctermfg=214
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#877d76    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#877d76    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/stark.vim
+++ b/vim/colors/stark.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2E2C2B  guifg=#DEDEDE    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2E2C2B  guifg=#DEDEDE    gui=none ctermbg=16 ctermfg=188
+hi NonText     guibg=bg  guifg=#DEDEDE   ctermbg=bg ctermfg=188
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#FFBB29   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#FFBB29   ctermbg=bg ctermfg=214
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#615953  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#615953  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#FFBB29    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#617FA0      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#617FA0  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#617FA0      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#FFBB29    ctermbg=bg  ctermfg=214
+hi Character   guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=202
+hi Number      guibg=bg    guifg=#617FA0      ctermbg=bg   ctermfg=67
+hi Boolean     guibg=bg    guifg=#617FA0  gui=none    ctermbg=bg   ctermfg=67
+hi Float       guibg=bg    guifg=#617FA0      ctermbg=bg   ctermfg=67
 
-hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Function    guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=202
+hi Statement   guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=202
 
-hi Conditional guibg=bg    guifg=#aaaaaa      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#aaaaaa      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#aaaaaa      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#aaaaaa      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#aaaaaa      ctermbg=bg  ctermfg=145
+hi Repeat      guibg=bg    guifg=#aaaaaa      ctermbg=bg   ctermfg=145
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#aaaaaa      ctermbg=bg   ctermfg=145
+hi Keyword     guibg=bg    guifg=#aaaaaa      ctermbg=bg  ctermfg=145
+hi Exception   guibg=bg    guifg=#F03113      ctermbg=bg  ctermfg=202
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#FFBB29   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#FFBB29   ctermbg=bg ctermfg=214
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#FFBB29      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#F03113      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#FFBB29    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#FFBB29      ctermbg=bg  ctermfg=214
+hi StorageClass   guibg=bg   guifg=#F03113      ctermbg=bg  ctermfg=202
+hi Structure      guibg=bg   guifg=#DEDEDE      ctermbg=bg  ctermfg=188
+hi Typedef    guibg=bg   guifg=#FFBB29    ctermbg=bg  ctermfg=214
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#877d76    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#877d76    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#DEDEDE        ctermbg=bg   ctermfg=188
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/super.vim
+++ b/vim/colors/super.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#15191D  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#15191D  guifg=#ffffff    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#5d67ad   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#5d67ad   ctermbg=bg ctermfg=61
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#465360  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#465360  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#F7A21B    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#D60257      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#F7A21B      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#F7A21B  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#F7A21B      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#F7A21B    ctermbg=bg  ctermfg=214
+hi Character   guibg=bg    guifg=#D60257      ctermbg=bg  ctermfg=161
+hi Number      guibg=bg    guifg=#F7A21B      ctermbg=bg   ctermfg=214
+hi Boolean     guibg=bg    guifg=#F7A21B  gui=none    ctermbg=bg   ctermfg=214
+hi Float       guibg=bg    guifg=#F7A21B      ctermbg=bg   ctermfg=214
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#D60257      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#D60257      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#D60257      ctermbg=bg  ctermfg=161
+hi Statement   guibg=bg    guifg=#D60257      ctermbg=bg  ctermfg=161
 
-hi Conditional guibg=bg    guifg=#5d67ad      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#5d67ad      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#5d67ad      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#5d67ad      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#D60257      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#5d67ad      ctermbg=bg  ctermfg=61
+hi Repeat      guibg=bg    guifg=#5d67ad      ctermbg=bg   ctermfg=61
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#5d67ad      ctermbg=bg   ctermfg=61
+hi Keyword     guibg=bg    guifg=#5d67ad      ctermbg=bg  ctermfg=61
+hi Exception   guibg=bg    guifg=#D60257      ctermbg=bg  ctermfg=161
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#5d67ad   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#5d67ad   ctermbg=bg ctermfg=61
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#5d67ad      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#D60257      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#5d67ad    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#5d67ad      ctermbg=bg  ctermfg=61
+hi StorageClass   guibg=bg   guifg=#D60257      ctermbg=bg  ctermfg=161
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#5d67ad    ctermbg=bg  ctermfg=61
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#64778a    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#64778a    ctermbg=59   ctermfg=66
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/tonic.vim
+++ b/vim/colors/tonic.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2a2f31  guifg=#eeeeee    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#eeeeee   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2a2f31  guifg=#eeeeee    gui=none ctermbg=17 ctermfg=231
+hi NonText     guibg=bg  guifg=#eeeeee   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#75A1A4   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#75A1A4   ctermbg=bg ctermfg=109
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#4a5356  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#4a5356  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#B8CD44    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#B8CD44      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#B8CD44      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#B8CD44  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#B8CD44      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#B8CD44    ctermbg=bg  ctermfg=149
+hi Character   guibg=bg    guifg=#B8CD44      ctermbg=bg  ctermfg=149
+hi Number      guibg=bg    guifg=#B8CD44      ctermbg=bg   ctermfg=149
+hi Boolean     guibg=bg    guifg=#B8CD44  gui=none    ctermbg=bg   ctermfg=149
+hi Float       guibg=bg    guifg=#B8CD44      ctermbg=bg   ctermfg=149
 
-hi Identifier  guibg=bg    guifg=#eeeeee      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#B8CD44      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#B8CD44      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#eeeeee      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#B8CD44      ctermbg=bg  ctermfg=149
+hi Statement   guibg=bg    guifg=#B8CD44      ctermbg=bg  ctermfg=149
 
-hi Conditional guibg=bg    guifg=#EF6E44      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#EF6E44      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#EF6E44      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#EF6E44      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#B8CD44      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#EF6E44      ctermbg=bg  ctermfg=203
+hi Repeat      guibg=bg    guifg=#EF6E44      ctermbg=bg   ctermfg=203
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#EF6E44      ctermbg=bg   ctermfg=203
+hi Keyword     guibg=bg    guifg=#EF6E44      ctermbg=bg  ctermfg=203
+hi Exception   guibg=bg    guifg=#B8CD44      ctermbg=bg  ctermfg=149
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#75A1A4   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#75A1A4   ctermbg=bg ctermfg=109
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#75A1A4      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#B8CD44      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#eeeeee      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#75A1A4    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#75A1A4      ctermbg=bg  ctermfg=109
+hi StorageClass   guibg=bg   guifg=#B8CD44      ctermbg=bg  ctermfg=149
+hi Structure      guibg=bg   guifg=#eeeeee      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#75A1A4    ctermbg=bg  ctermfg=109
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#67757a    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#67757a    ctermbg=59   ctermfg=66
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#eeeeee        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#eeeeee        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/tribal.vim
+++ b/vim/colors/tribal.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#19191d  guifg=#ffffff    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#ffffff   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#19191d  guifg=#ffffff    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#ffffff   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#c43535   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#c43535   ctermbg=bg ctermfg=167
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#4a4a54  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#4a4a54  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#64aeb3    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#5f5582      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#64aeb3      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#64aeb3  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#64aeb3      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#64aeb3    ctermbg=bg  ctermfg=73
+hi Character   guibg=bg    guifg=#5f5582      ctermbg=bg  ctermfg=60
+hi Number      guibg=bg    guifg=#64aeb3      ctermbg=bg   ctermfg=73
+hi Boolean     guibg=bg    guifg=#64aeb3  gui=none    ctermbg=bg   ctermfg=73
+hi Float       guibg=bg    guifg=#64aeb3      ctermbg=bg   ctermfg=73
 
-hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#5f5582      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#5f5582      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#5f5582      ctermbg=bg  ctermfg=60
+hi Statement   guibg=bg    guifg=#5f5582      ctermbg=bg  ctermfg=60
 
-hi Conditional guibg=bg    guifg=#5f5582      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#5f5582      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#5f5582      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#5f5582      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#5f5582      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#5f5582      ctermbg=bg  ctermfg=60
+hi Repeat      guibg=bg    guifg=#5f5582      ctermbg=bg   ctermfg=60
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#5f5582      ctermbg=bg   ctermfg=60
+hi Keyword     guibg=bg    guifg=#5f5582      ctermbg=bg  ctermfg=60
+hi Exception   guibg=bg    guifg=#5f5582      ctermbg=bg  ctermfg=60
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#c43535   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#c43535   ctermbg=bg ctermfg=167
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#c43535      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#5f5582      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#c43535    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#c43535      ctermbg=bg  ctermfg=167
+hi StorageClass   guibg=bg   guifg=#5f5582      ctermbg=bg  ctermfg=60
+hi Structure      guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#c43535    ctermbg=bg  ctermfg=167
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#62626e    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#62626e    ctermbg=59   ctermfg=59
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#ffffff        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#ffffff        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/tron-contrast.vim
+++ b/vim/colors/tron-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#07090b  guifg=#aec2e0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#aec2e0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#07090b  guifg=#aec2e0    gui=none ctermbg=16 ctermfg=146
+hi NonText     guibg=bg  guifg=#aec2e0   ctermbg=bg ctermfg=146
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#267fb5   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#267fb5   ctermbg=bg ctermfg=31
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#324357  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#324357  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#6ee2ff    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#6ee2ff      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#6ee2ff  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#6ee2ff      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#6ee2ff    ctermbg=bg  ctermfg=81
+hi Character   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Number      guibg=bg    guifg=#6ee2ff      ctermbg=bg   ctermfg=81
+hi Boolean     guibg=bg    guifg=#6ee2ff  gui=none    ctermbg=bg   ctermfg=81
+hi Float       guibg=bg    guifg=#6ee2ff      ctermbg=bg   ctermfg=81
 
-hi Identifier  guibg=bg    guifg=#aec2e0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#aec2e0      ctermbg=bg  ctermfg=146
+hi Function    guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Statement   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
 
-hi Conditional guibg=bg    guifg=#748aa6      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#748aa6      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#748aa6      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#748aa6      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#748aa6      ctermbg=bg  ctermfg=103
+hi Repeat      guibg=bg    guifg=#748aa6      ctermbg=bg   ctermfg=103
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#748aa6      ctermbg=bg   ctermfg=103
+hi Keyword     guibg=bg    guifg=#748aa6      ctermbg=bg  ctermfg=103
+hi Exception   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#267fb5   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#267fb5   ctermbg=bg ctermfg=31
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#267fb5      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#aec2e0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#267fb5    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#267fb5      ctermbg=bg  ctermfg=31
+hi StorageClass   guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Structure      guibg=bg   guifg=#aec2e0      ctermbg=bg  ctermfg=146
+hi Typedef    guibg=bg   guifg=#267fb5    ctermbg=bg  ctermfg=31
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#4d6785    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#4d6785    ctermbg=59   ctermfg=60
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#aec2e0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#aec2e0        ctermbg=bg   ctermfg=146
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/tron.vim
+++ b/vim/colors/tron.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#14191f  guifg=#aec2e0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#aec2e0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#14191f  guifg=#aec2e0    gui=none ctermbg=16 ctermfg=146
+hi NonText     guibg=bg  guifg=#aec2e0   ctermbg=bg ctermfg=146
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#267fb5   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#267fb5   ctermbg=bg ctermfg=31
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#324357  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#324357  gui=none    ctermbg=bg   ctermfg=59
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#6ee2ff    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#6ee2ff      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#6ee2ff  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#6ee2ff      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#6ee2ff    ctermbg=bg  ctermfg=81
+hi Character   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Number      guibg=bg    guifg=#6ee2ff      ctermbg=bg   ctermfg=81
+hi Boolean     guibg=bg    guifg=#6ee2ff  gui=none    ctermbg=bg   ctermfg=81
+hi Float       guibg=bg    guifg=#6ee2ff      ctermbg=bg   ctermfg=81
 
-hi Identifier  guibg=bg    guifg=#aec2e0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#aec2e0      ctermbg=bg  ctermfg=146
+hi Function    guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Statement   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
 
-hi Conditional guibg=bg    guifg=#748aa6      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#748aa6      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#748aa6      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#748aa6      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#748aa6      ctermbg=bg  ctermfg=103
+hi Repeat      guibg=bg    guifg=#748aa6      ctermbg=bg   ctermfg=103
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#748aa6      ctermbg=bg   ctermfg=103
+hi Keyword     guibg=bg    guifg=#748aa6      ctermbg=bg  ctermfg=103
+hi Exception   guibg=bg    guifg=#ffffff      ctermbg=bg  ctermfg=231
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#267fb5   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#267fb5   ctermbg=bg ctermfg=31
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#267fb5      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#aec2e0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#267fb5    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#267fb5      ctermbg=bg  ctermfg=31
+hi StorageClass   guibg=bg   guifg=#ffffff      ctermbg=bg  ctermfg=231
+hi Structure      guibg=bg   guifg=#aec2e0      ctermbg=bg  ctermfg=146
+hi Typedef    guibg=bg   guifg=#267fb5    ctermbg=bg  ctermfg=31
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#4d6785    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#4d6785    ctermbg=59   ctermfg=60
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#aec2e0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#aec2e0        ctermbg=bg   ctermfg=146
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/turnip-contrast.vim
+++ b/vim/colors/turnip-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#080809  guifg=#EDE0CE    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#EDE0CE   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#080809  guifg=#EDE0CE    gui=none ctermbg=16 ctermfg=224
+hi NonText     guibg=bg  guifg=#EDE0CE   ctermbg=bg ctermfg=224
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#92B55F   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#92B55F   ctermbg=bg ctermfg=107
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#E8DA5E    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#E8DA5E      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#E8DA5E  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#E8DA5E      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#E8DA5E    ctermbg=bg  ctermfg=185
+hi Character   guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=66
+hi Number      guibg=bg    guifg=#E8DA5E      ctermbg=bg   ctermfg=185
+hi Boolean     guibg=bg    guifg=#E8DA5E  gui=none    ctermbg=bg   ctermfg=185
+hi Float       guibg=bg    guifg=#E8DA5E      ctermbg=bg   ctermfg=185
 
-hi Identifier  guibg=bg    guifg=#EDE0CE      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#EDE0CE      ctermbg=bg  ctermfg=224
+hi Function    guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=66
+hi Statement   guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=66
 
-hi Conditional guibg=bg    guifg=#92B55F      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#92B55F      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#92B55F      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#92B55F      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#92B55F      ctermbg=bg  ctermfg=107
+hi Repeat      guibg=bg    guifg=#92B55F      ctermbg=bg   ctermfg=107
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#92B55F      ctermbg=bg   ctermfg=107
+hi Keyword     guibg=bg    guifg=#92B55F      ctermbg=bg  ctermfg=107
+hi Exception   guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=66
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#92B55F   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#92B55F   ctermbg=bg ctermfg=107
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#92B55F      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#487D76      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#EDE0CE      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#92B55F    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#92B55F      ctermbg=bg  ctermfg=107
+hi StorageClass   guibg=bg   guifg=#487D76      ctermbg=bg  ctermfg=66
+hi Structure      guibg=bg   guifg=#EDE0CE      ctermbg=bg  ctermfg=224
+hi Typedef    guibg=bg   guifg=#92B55F    ctermbg=bg  ctermfg=107
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#aea395    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#aea395    ctermbg=59   ctermfg=144
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#EDE0CE        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#EDE0CE        ctermbg=bg   ctermfg=224
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/turnip.vim
+++ b/vim/colors/turnip.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#1a1b1d  guifg=#EDE0CE    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#EDE0CE   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#1a1b1d  guifg=#EDE0CE    gui=none ctermbg=16 ctermfg=224
+hi NonText     guibg=bg  guifg=#EDE0CE   ctermbg=bg ctermfg=224
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#92B55F   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#92B55F   ctermbg=bg ctermfg=107
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#E8DA5E    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#E8DA5E      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#E8DA5E  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#E8DA5E      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#E8DA5E    ctermbg=bg  ctermfg=185
+hi Character   guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=66
+hi Number      guibg=bg    guifg=#E8DA5E      ctermbg=bg   ctermfg=185
+hi Boolean     guibg=bg    guifg=#E8DA5E  gui=none    ctermbg=bg   ctermfg=185
+hi Float       guibg=bg    guifg=#E8DA5E      ctermbg=bg   ctermfg=185
 
-hi Identifier  guibg=bg    guifg=#EDE0CE      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#EDE0CE      ctermbg=bg  ctermfg=224
+hi Function    guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=66
+hi Statement   guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=66
 
-hi Conditional guibg=bg    guifg=#92B55F      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#92B55F      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#92B55F      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#92B55F      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#92B55F      ctermbg=bg  ctermfg=107
+hi Repeat      guibg=bg    guifg=#92B55F      ctermbg=bg   ctermfg=107
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#92B55F      ctermbg=bg   ctermfg=107
+hi Keyword     guibg=bg    guifg=#92B55F      ctermbg=bg  ctermfg=107
+hi Exception   guibg=bg    guifg=#487D76      ctermbg=bg  ctermfg=66
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#92B55F   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#92B55F   ctermbg=bg ctermfg=107
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#92B55F      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#487D76      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#EDE0CE      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#92B55F    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#92B55F      ctermbg=bg  ctermfg=107
+hi StorageClass   guibg=bg   guifg=#487D76      ctermbg=bg  ctermfg=66
+hi Structure      guibg=bg   guifg=#EDE0CE      ctermbg=bg  ctermfg=224
+hi Typedef    guibg=bg   guifg=#92B55F    ctermbg=bg  ctermfg=107
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#aea395    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#aea395    ctermbg=59   ctermfg=144
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#EDE0CE        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#EDE0CE        ctermbg=bg   ctermfg=224
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/userscape.vim
+++ b/vim/colors/userscape.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#F5F8FC  guifg=#879BB0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#879BB0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#F5F8FC  guifg=#879BB0    gui=none ctermbg=231 ctermfg=109
+hi NonText     guibg=bg  guifg=#879BB0   ctermbg=bg ctermfg=109
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#A8C0E0   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#A8C0E0   ctermbg=bg ctermfg=146
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#bbbbbb  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#bbbbbb  gui=none    ctermbg=bg   ctermfg=145
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#E3BD14    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#355B8C      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#DE4D3A      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#DE4D3A  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#DE4D3A      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#E3BD14    ctermbg=bg  ctermfg=178
+hi Character   guibg=bg    guifg=#355B8C      ctermbg=bg  ctermfg=60
+hi Number      guibg=bg    guifg=#DE4D3A      ctermbg=bg   ctermfg=167
+hi Boolean     guibg=bg    guifg=#DE4D3A  gui=none    ctermbg=bg   ctermfg=167
+hi Float       guibg=bg    guifg=#DE4D3A      ctermbg=bg   ctermfg=167
 
-hi Identifier  guibg=bg    guifg=#879BB0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#355B8C      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#355B8C      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#879BB0      ctermbg=bg  ctermfg=109
+hi Function    guibg=bg    guifg=#355B8C      ctermbg=bg  ctermfg=60
+hi Statement   guibg=bg    guifg=#355B8C      ctermbg=bg  ctermfg=60
 
-hi Conditional guibg=bg    guifg=#808C9C      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#808C9C      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#808C9C      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#808C9C      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#355B8C      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#808C9C      ctermbg=bg  ctermfg=103
+hi Repeat      guibg=bg    guifg=#808C9C      ctermbg=bg   ctermfg=103
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#808C9C      ctermbg=bg   ctermfg=103
+hi Keyword     guibg=bg    guifg=#808C9C      ctermbg=bg  ctermfg=103
+hi Exception   guibg=bg    guifg=#355B8C      ctermbg=bg  ctermfg=60
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#A8C0E0   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#A8C0E0   ctermbg=bg ctermfg=146
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#A8C0E0      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#355B8C      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#879BB0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#A8C0E0    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#A8C0E0      ctermbg=bg  ctermfg=146
+hi StorageClass   guibg=bg   guifg=#355B8C      ctermbg=bg  ctermfg=60
+hi Structure      guibg=bg   guifg=#879BB0      ctermbg=bg  ctermfg=109
+hi Typedef    guibg=bg   guifg=#A8C0E0    ctermbg=bg  ctermfg=146
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#7d7d7d    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#7d7d7d    ctermbg=59   ctermfg=102
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#879BB0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#879BB0        ctermbg=bg   ctermfg=109
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/yule.vim
+++ b/vim/colors/yule.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#2B2A27  guifg=#EDE0CE    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#EDE0CE   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#2B2A27  guifg=#EDE0CE    gui=none ctermbg=16 ctermfg=224
+hi NonText     guibg=bg  guifg=#EDE0CE   ctermbg=bg ctermfg=224
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#39B81F   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#39B81F   ctermbg=bg ctermfg=70
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#7A7267  gui=none    ctermbg=bg   ctermfg=95
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#EBB626    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#D63131      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#EBB626      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#EBB626  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#EBB626      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#EBB626    ctermbg=bg  ctermfg=214
+hi Character   guibg=bg    guifg=#D63131      ctermbg=bg  ctermfg=167
+hi Number      guibg=bg    guifg=#EBB626      ctermbg=bg   ctermfg=214
+hi Boolean     guibg=bg    guifg=#EBB626  gui=none    ctermbg=bg   ctermfg=214
+hi Float       guibg=bg    guifg=#EBB626      ctermbg=bg   ctermfg=214
 
-hi Identifier  guibg=bg    guifg=#EDE0CE      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#D63131      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#D63131      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#EDE0CE      ctermbg=bg  ctermfg=224
+hi Function    guibg=bg    guifg=#D63131      ctermbg=bg  ctermfg=167
+hi Statement   guibg=bg    guifg=#D63131      ctermbg=bg  ctermfg=167
 
-hi Conditional guibg=bg    guifg=#39B81F      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#39B81F      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#39B81F      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#39B81F      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#D63131      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#39B81F      ctermbg=bg  ctermfg=70
+hi Repeat      guibg=bg    guifg=#39B81F      ctermbg=bg   ctermfg=70
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#39B81F      ctermbg=bg   ctermfg=70
+hi Keyword     guibg=bg    guifg=#39B81F      ctermbg=bg  ctermfg=70
+hi Exception   guibg=bg    guifg=#D63131      ctermbg=bg  ctermfg=167
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#39B81F   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#39B81F   ctermbg=bg ctermfg=70
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#39B81F      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#D63131      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#EDE0CE      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#39B81F    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#39B81F      ctermbg=bg  ctermfg=70
+hi StorageClass   guibg=bg   guifg=#D63131      ctermbg=bg  ctermfg=167
+hi Structure      guibg=bg   guifg=#EDE0CE      ctermbg=bg  ctermfg=224
+hi Typedef    guibg=bg   guifg=#39B81F    ctermbg=bg  ctermfg=70
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#bdae9a    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#bdae9a    ctermbg=59   ctermfg=144
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#EDE0CE        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#EDE0CE        ctermbg=bg   ctermfg=224
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/zacks-contrast.vim
+++ b/vim/colors/zacks-contrast.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#000000  guifg=#f0f0f0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#f0f0f0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#000000  guifg=#f0f0f0    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#f0f0f0   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#9c7ddb   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#9c7ddb   ctermbg=bg ctermfg=140
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#777777  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#777777  gui=none    ctermbg=bg   ctermfg=102
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#bcd42a    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#bcd42a      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#bcd42a  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#bcd42a      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#bcd42a    ctermbg=bg  ctermfg=148
+hi Character   guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#bcd42a      ctermbg=bg   ctermfg=148
+hi Boolean     guibg=bg    guifg=#bcd42a  gui=none    ctermbg=bg   ctermfg=148
+hi Float       guibg=bg    guifg=#bcd42a      ctermbg=bg   ctermfg=148
 
-hi Identifier  guibg=bg    guifg=#f0f0f0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#f0f0f0      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#ff6a38      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#ff6a38      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=203
+hi Repeat      guibg=bg    guifg=#ff6a38      ctermbg=bg   ctermfg=203
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#ff6a38      ctermbg=bg   ctermfg=203
+hi Keyword     guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=203
+hi Exception   guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#9c7ddb   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#9c7ddb   ctermbg=bg ctermfg=140
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#9c7ddb      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#ff6a38      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#f0f0f0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#9c7ddb    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#9c7ddb      ctermbg=bg  ctermfg=140
+hi StorageClass   guibg=bg   guifg=#ff6a38      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#f0f0f0      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#9c7ddb    ctermbg=bg  ctermfg=140
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#afafaf    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#afafaf    ctermbg=59   ctermfg=145
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#f0f0f0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#f0f0f0        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4

--- a/vim/colors/zacks.vim
+++ b/vim/colors/zacks.vim
@@ -14,85 +14,85 @@ syntax reset
 
 " Colors for the User Interface.
 
-hi Cursor      guibg=#cc4455  guifg=white     ctermbg=4 ctermfg=15
+hi Cursor      guibg=#cc4455  guifg=white     ctermbg=167 ctermfg=15
 hi link CursorIM Cursor
-hi Normal      guibg=#222222  guifg=#f0f0f0    gui=none ctermbg=0 ctermfg=15
-hi NonText     guibg=bg  guifg=#f0f0f0   ctermbg=8 ctermfg=14
-hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi Normal      guibg=#222222  guifg=#f0f0f0    gui=none ctermbg=16 ctermfg=231
+hi NonText     guibg=bg  guifg=#f0f0f0   ctermbg=bg ctermfg=231
+hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=66 ctermfg=15
 
-hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
+hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=145
 
-hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=10
+hi Directory   guibg=bg       guifg=#337700  gui=none ctermbg=bg ctermfg=64
 
-hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=1 ctermfg=15
+hi IncSearch   guibg=#0066cc  guifg=white    gui=none ctermbg=26 ctermfg=15
 hi link Seach IncSearch
 
 hi SpecialKey  guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 hi Titled      guibg=bg guifg=fg       gui=none ctermbg=bg ctermfg=fg
 
-hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=12
-hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=14
+hi ErrorMsg    guibg=bg guifg=#ff0000   ctermbg=bg ctermfg=196
+hi ModeMsg     guibg=bg guifg=#ffeecc  gui=none ctermbg=bg ctermfg=230
 hi link  MoreMsg     ModeMsg
-hi Question    guibg=bg guifg=#9c7ddb   ctermbg=bg ctermfg=10
+hi Question    guibg=bg guifg=#9c7ddb   ctermbg=bg ctermfg=140
 hi link  WarningMsg  ErrorMsg
 
-hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=14 ctermfg=0
-hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
-hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=4  ctermfg=11
+hi StatusLine     guibg=#ffeecc  guifg=black     ctermbg=230 ctermfg=0
+hi StatusLineNC   guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
+hi VertSplit      guibg=#cc4455  guifg=white    gui=none ctermbg=167  ctermfg=11
 
-hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=1 ctermfg=fg
-hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=2 ctermfg=fg
-hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=4 ctermfg=fg
-hi DiffText    guibg=#884444  guifg=fg     ctermbg=4 ctermfg=fg
+hi DiffAdd     guibg=#446688  guifg=fg    gui=none ctermbg=60 ctermfg=fg
+hi DiffChange  guibg=#558855  guifg=fg    gui=none ctermbg=65 ctermfg=fg
+hi DiffDelete  guibg=#884444  guifg=fg    gui=none ctermbg=95 ctermfg=fg
+hi DiffText    guibg=#884444  guifg=fg     ctermbg=95 ctermfg=fg
 
 " Colors for Syntax Highlighting.
 
-hi Comment  guibg=bg  guifg=#777777  gui=none    ctermbg=8   ctermfg=7
+hi Comment  guibg=bg  guifg=#777777  gui=none    ctermbg=bg   ctermfg=102
 
-hi Constant    guibg=bg    guifg=white        ctermbg=8   ctermfg=15
-hi String      guibg=bg    guifg=#bcd42a    ctermbg=bg  ctermfg=14
-hi Character   guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=14
-hi Number      guibg=bg    guifg=#bcd42a      ctermbg=1   ctermfg=15
-hi Boolean     guibg=bg    guifg=#bcd42a  gui=none    ctermbg=1   ctermfg=15
-hi Float       guibg=bg    guifg=#bcd42a      ctermbg=1   ctermfg=15
+hi Constant    guibg=bg    guifg=white        ctermbg=bg   ctermfg=15
+hi String      guibg=bg    guifg=#bcd42a    ctermbg=bg  ctermfg=148
+hi Character   guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=203
+hi Number      guibg=bg    guifg=#bcd42a      ctermbg=bg   ctermfg=148
+hi Boolean     guibg=bg    guifg=#bcd42a  gui=none    ctermbg=bg   ctermfg=148
+hi Float       guibg=bg    guifg=#bcd42a      ctermbg=bg   ctermfg=148
 
-hi Identifier  guibg=bg    guifg=#f0f0f0      ctermbg=bg  ctermfg=12
-hi Function    guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=12
-hi Statement   guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=14
+hi Identifier  guibg=bg    guifg=#f0f0f0      ctermbg=bg  ctermfg=231
+hi Function    guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=203
+hi Statement   guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=203
 
-hi Conditional guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=12
-hi Repeat      guibg=bg    guifg=#ff6a38      ctermbg=4   ctermfg=14
-hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=13
-hi Operator    guibg=bg    guifg=#ff6a38      ctermbg=6   ctermfg=15
-hi Keyword     guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=10
-hi Exception   guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=10
+hi Conditional guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=203
+hi Repeat      guibg=bg    guifg=#ff6a38      ctermbg=bg   ctermfg=203
+hi Label       guibg=bg    guifg=#ffccff      ctermbg=bg   ctermfg=225
+hi Operator    guibg=bg    guifg=#ff6a38      ctermbg=bg   ctermfg=203
+hi Keyword     guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=203
+hi Exception   guibg=bg    guifg=#ff6a38      ctermbg=bg  ctermfg=203
 
-hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=4  ctermfg=14
-hi Include    guibg=bg   guifg=#9c7ddb   ctermbg=bg ctermfg=10
+hi PreProc    guibg=bg   guifg=#ffcc99   ctermbg=bg  ctermfg=222
+hi Include    guibg=bg   guifg=#9c7ddb   ctermbg=bg ctermfg=140
 hi link Define    Include
 hi link Macro     Include
 hi link PreCondit Include
 
-hi Type       guibg=bg   guifg=#9c7ddb      ctermbg=bg  ctermfg=12
-hi StorageClass   guibg=bg   guifg=#ff6a38      ctermbg=bg  ctermfg=10
-hi Structure      guibg=bg   guifg=#f0f0f0      ctermbg=bg  ctermfg=10
-hi Typedef    guibg=bg   guifg=#9c7ddb    ctermbg=bg  ctermfg=10
+hi Type       guibg=bg   guifg=#9c7ddb      ctermbg=bg  ctermfg=140
+hi StorageClass   guibg=bg   guifg=#ff6a38      ctermbg=bg  ctermfg=203
+hi Structure      guibg=bg   guifg=#f0f0f0      ctermbg=bg  ctermfg=231
+hi Typedef    guibg=bg   guifg=#9c7ddb    ctermbg=bg  ctermfg=140
 
-hi Special    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Tag        guibg=bg   guifg=#bbddff      ctermbg=1   ctermfg=15
-hi Delimiter      guibg=bg   guifg=fg       ctermbg=1   ctermfg=fg
-hi SpecialComment guibg=#334455  guifg=#afafaf    ctermbg=1   ctermfg=15
-hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=8   ctermfg=12
+hi Special    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi SpecialChar    guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Tag        guibg=bg   guifg=#bbddff      ctermbg=bg   ctermfg=153
+hi Delimiter      guibg=bg   guifg=fg       ctermbg=bg   ctermfg=fg
+hi SpecialComment guibg=#334455  guifg=#afafaf    ctermbg=59   ctermfg=145
+hi Debug      guibg=bg   guifg=#ff9999  gui=none    ctermbg=bg   ctermfg=210
 
-hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=9 cterm=underline
+hi Underlined guibg=bg guifg=#99ccff gui=underline ctermbg=bg ctermfg=117 cterm=underline
 
-hi Title    guibg=bg  guifg=#f0f0f0        ctermbg=1   ctermfg=15
-hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=8
-hi Error    guibg=#ff0000  guifg=white        ctermbg=12  ctermfg=15
-hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=1   ctermfg=12
+hi Title    guibg=bg  guifg=#f0f0f0        ctermbg=bg   ctermfg=231
+hi Ignore   guibg=bg       guifg=#cccccc    ctermbg=bg  ctermfg=188
+hi Error    guibg=#ff0000  guifg=white        ctermbg=196  ctermfg=15
+hi Todo     guibg=#556677  guifg=#ff0000      ctermbg=60   ctermfg=196
 
-hi htmlH2 guibg=bg guifg=fg  ctermbg=8 ctermfg=fg
+hi htmlH2 guibg=bg guifg=fg  ctermbg=bg ctermfg=fg
 hi link htmlH3 htmlH2
 hi link htmlH4 htmlH3
 hi link htmlH5 htmlH4


### PR DESCRIPTION
Correctly converted the hex rgb values for the gui version of the
colorschemes so the term version displays as a closer approximation.
