### PR TITLE
Fix corrupted icons after Spacegray theme update

### DIFF
--- a/sublimeui/arstotzka.sublime-theme
+++ b/sublimeui/arstotzka.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [165, 227, 208], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [53, 51, 50] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [113, 111, 110], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [165, 227, 208] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [165, 227, 208] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [41, 67, 67], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [43, 41, 40], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [43, 41, 40], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [43, 41, 40], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [43, 41, 40], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [43, 41, 40], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [43, 41, 40], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [43, 41, 40], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [43, 41, 40], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [43, 41, 40], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [43, 41, 40], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/azure.sublime-theme
+++ b/sublimeui/azure.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [100, 174, 179], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [44, 49, 58] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [104, 109, 118], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [100, 174, 179] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [100, 174, 179] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [42, 72, 99], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [34, 39, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [34, 39, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [34, 39, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [34, 39, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [34, 39, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [34, 39, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [34, 39, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [34, 39, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [34, 39, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [34, 39, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/bold.sublime-theme
+++ b/sublimeui/bold.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [247, 162, 27], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [62, 58, 58] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [122, 118, 118], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [247, 162, 27] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [247, 162, 27] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [200, 58, 35], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [52, 48, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [52, 48, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [52, 48, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [52, 48, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [52, 48, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [52, 48, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [52, 48, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [52, 48, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [52, 48, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [52, 48, 48], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/boxuk.sublime-theme
+++ b/sublimeui/boxuk.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [21, 184, 174], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [255, 255, 255] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [255, 255, 255], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [21, 184, 174] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [21, 184, 174] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [0, 117, 78], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [255, 255, 255], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [255, 255, 255], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [255, 255, 255], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [255, 255, 255], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [255, 255, 255], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [255, 255, 255], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [255, 255, 255], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [255, 255, 255], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [255, 255, 255], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [255, 255, 255], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/carbonight.sublime-theme
+++ b/sublimeui/carbonight.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [255, 255, 255], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [66, 64, 63] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [126, 124, 123], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [255, 255, 255] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [255, 255, 255] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [100, 100, 100], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/chocolate.sublime-theme
+++ b/sublimeui/chocolate.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [247, 162, 27], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [41, 35, 28] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [101, 95, 88], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [247, 162, 27] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [247, 162, 27] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [164, 142, 111], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [31, 25, 18], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [31, 25, 18], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [31, 25, 18], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [31, 25, 18], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [31, 25, 18], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [31, 25, 18], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [31, 25, 18], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [31, 25, 18], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [31, 25, 18], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [31, 25, 18], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/carbonight-contrast.sublime-theme
+++ b/sublimeui/contrast/carbonight-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [255, 255, 255], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [20, 20, 20] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [80, 80, 80], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [255, 255, 255] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [255, 255, 255] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [100, 100, 100], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/darkside-contrast.sublime-theme
+++ b/sublimeui/contrast/darkside-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [242, 212, 44], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [20, 20, 20] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [80, 80, 80], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [242, 212, 44] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [242, 212, 44] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [192, 12, 0], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/earthsong-contrast.sublime-theme
+++ b/sublimeui/contrast/earthsong-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [248, 187, 57], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [38, 36, 35] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [98, 96, 95], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [248, 187, 57] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [248, 187, 57] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [179, 80, 37], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [28, 26, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [28, 26, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [28, 26, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [28, 26, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [28, 26, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [28, 26, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [28, 26, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [28, 26, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [28, 26, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [28, 26, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/freshcut-contrast.sublime-theme
+++ b/sublimeui/contrast/freshcut-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [233, 238, 0], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [20, 20, 20] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [80, 80, 80], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [233, 238, 0] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [233, 238, 0] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [0, 128, 158], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/frontier-contrast.sublime-theme
+++ b/sublimeui/contrast/frontier-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [248, 187, 57], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [37, 35, 34] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [97, 95, 94], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [248, 187, 57] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [248, 187, 57] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [202, 18, 18], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [27, 25, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [27, 25, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [27, 25, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [27, 25, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [27, 25, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [27, 25, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [27, 25, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [27, 25, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [27, 25, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [27, 25, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/gloom-contrast.sublime-theme
+++ b/sublimeui/contrast/gloom-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [188, 212, 42], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [35, 38, 35] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [95, 98, 95], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [188, 212, 42] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [188, 212, 42] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [215, 53, 16], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [25, 28, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [25, 28, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [25, 28, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [25, 28, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [25, 28, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [25, 28, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [25, 28, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [25, 28, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [25, 28, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [25, 28, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/glowfish-contrast.sublime-theme
+++ b/sublimeui/contrast/glowfish-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [248, 187, 57], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [29, 31, 27] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [89, 91, 87], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [248, 187, 57] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [248, 187, 57] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [179, 80, 37], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [19, 21, 17], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [19, 21, 17], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [19, 21, 17], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [19, 21, 17], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [19, 21, 17], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [19, 21, 17], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [19, 21, 17], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [19, 21, 17], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [19, 21, 17], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [19, 21, 17], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/goldfish-contrast.sublime-theme
+++ b/sublimeui/contrast/goldfish-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [243, 110, 58], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [32, 33, 34] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [92, 93, 94], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [243, 110, 58] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [243, 110, 58] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [210, 65, 0], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [22, 23, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [22, 23, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [22, 23, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [22, 23, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [22, 23, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [22, 23, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [22, 23, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [22, 23, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [22, 23, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [22, 23, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/grunge-contrast.sublime-theme
+++ b/sublimeui/contrast/grunge-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [209, 242, 165], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [32, 32, 30] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [92, 92, 90], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [209, 242, 165] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [209, 242, 165] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [205, 65, 105], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [22, 22, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [22, 22, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [22, 22, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [22, 22, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [22, 22, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [22, 22, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [22, 22, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [22, 22, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [22, 22, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [22, 22, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/halflife-contrast.sublime-theme
+++ b/sublimeui/contrast/halflife-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [249, 212, 35], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [20, 20, 20] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [80, 80, 80], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [249, 212, 35] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [249, 212, 35] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [85, 97, 105], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/hyrule-contrast.sublime-theme
+++ b/sublimeui/contrast/hyrule-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [206, 131, 13], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [32, 32, 32] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [92, 92, 92], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [206, 131, 13] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [206, 131, 13] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [46, 118, 0], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/iceberg-contrast.sublime-theme
+++ b/sublimeui/contrast/iceberg-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [255, 255, 255], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [31, 34, 34] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [91, 94, 94], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [255, 255, 255] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [255, 255, 255] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [5, 101, 121], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [21, 24, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [21, 24, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [21, 24, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [21, 24, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [21, 24, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [21, 24, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [21, 24, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [21, 24, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [21, 24, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [21, 24, 24], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/juicy-contrast.sublime-theme
+++ b/sublimeui/contrast/juicy-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [59, 199, 184], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [20, 20, 20] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [80, 80, 80], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [59, 199, 184] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [59, 199, 184] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [19, 159, 144], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/keen-contrast.sublime-theme
+++ b/sublimeui/contrast/keen-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [181, 219, 153], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [20, 20, 20] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [80, 80, 80], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [181, 219, 153] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [181, 219, 153] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [95, 63, 143], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/laravel-contrast.sublime-theme
+++ b/sublimeui/contrast/laravel-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [253, 202, 73], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [20, 20, 20] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [80, 80, 80], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [253, 202, 73] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [253, 202, 73] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [212, 67, 0], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/lavender-contrast.sublime-theme
+++ b/sublimeui/contrast/lavender-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [245, 176, 239], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [28, 27, 29] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [88, 87, 89], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [245, 176, 239] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [245, 176, 239] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [142, 47, 215], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [18, 17, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [18, 17, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [18, 17, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [18, 17, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [18, 17, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [18, 17, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [18, 17, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [18, 17, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [18, 17, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [18, 17, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/mellow-contrast.sublime-theme
+++ b/sublimeui/contrast/mellow-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [248, 187, 57], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [31, 30, 29] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [91, 90, 89], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [248, 187, 57] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [248, 187, 57] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [0, 89, 89], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [21, 20, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [21, 20, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [21, 20, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [21, 20, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [21, 20, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [21, 20, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [21, 20, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [21, 20, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [21, 20, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [21, 20, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/mud-contrast.sublime-theme
+++ b/sublimeui/contrast/mud-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [181, 219, 153], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [33, 31, 31] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [93, 91, 91], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [181, 219, 153] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [181, 219, 153] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [205, 42, 17], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [23, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [23, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [23, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [23, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [23, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [23, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [23, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [23, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [23, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [23, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/patriot-contrast.sublime-theme
+++ b/sublimeui/contrast/patriot-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [55, 144, 222], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [33, 34, 35] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [93, 94, 95], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [55, 144, 222] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [55, 144, 222] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [6, 71, 177], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [23, 24, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [23, 24, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [23, 24, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [23, 24, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [23, 24, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [23, 24, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [23, 24, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [23, 24, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [23, 24, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [23, 24, 25], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/peacock-contrast.sublime-theme
+++ b/sublimeui/contrast/peacock-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [188, 212, 42], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [32, 32, 31] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [92, 92, 91], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [188, 212, 42] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [188, 212, 42] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [215, 53, 16], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [22, 22, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [22, 22, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [22, 22, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [22, 22, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [22, 22, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [22, 22, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [22, 22, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [22, 22, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [22, 22, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [22, 22, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/potpourri-contrast.sublime-theme
+++ b/sublimeui/contrast/potpourri-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [184, 102, 250], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [33, 32, 32] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [93, 92, 92], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [184, 102, 250] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [184, 102, 250] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [197, 0, 43], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [23, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [23, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [23, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [23, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [23, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [23, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [23, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [23, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [23, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [23, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/revelation-contrast.sublime-theme
+++ b/sublimeui/contrast/revelation-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [255, 187, 41], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [32, 31, 31] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [92, 91, 91], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [255, 187, 41] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [255, 187, 41] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [57, 87, 120], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [22, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [22, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [22, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [22, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [22, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [22, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [22, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [22, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [22, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [22, 21, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/slime-contrast.sublime-theme
+++ b/sublimeui/contrast/slime-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [250, 255, 219], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [31, 32, 33] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [91, 92, 93], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [250, 255, 219] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [250, 255, 219] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [66, 118, 157], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [21, 22, 23], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [21, 22, 23], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [21, 22, 23], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [21, 22, 23], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [21, 22, 23], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [21, 22, 23], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [21, 22, 23], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [21, 22, 23], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [21, 22, 23], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [21, 22, 23], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/snappy-contrast.sublime-theme
+++ b/sublimeui/contrast/snappy-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [78, 161, 223], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [32, 32, 32] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [92, 92, 92], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [78, 161, 223] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [78, 161, 223] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [206, 57, 43], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [22, 22, 22], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/solarflare-contrast.sublime-theme
+++ b/sublimeui/contrast/solarflare-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [237, 229, 116], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [20, 20, 20] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [80, 80, 80], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [237, 229, 116] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [237, 229, 116] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [215, 38, 40], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/sourlick-contrast.sublime-theme
+++ b/sublimeui/contrast/sourlick-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [228, 255, 51], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [26, 26, 26] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [86, 86, 86], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [228, 255, 51] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [228, 255, 51] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [98, 154, 82], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [16, 16, 16], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [16, 16, 16], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [16, 16, 16], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [16, 16, 16], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [16, 16, 16], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [16, 16, 16], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [16, 16, 16], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [16, 16, 16], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [16, 16, 16], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [16, 16, 16], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/stark-contrast.sublime-theme
+++ b/sublimeui/contrast/stark-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [255, 187, 41], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [31, 30, 30] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [91, 90, 90], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [255, 187, 41] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [255, 187, 41] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [200, 9, 0], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [21, 20, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [21, 20, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [21, 20, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [21, 20, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [21, 20, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [21, 20, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [21, 20, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [21, 20, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [21, 20, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [21, 20, 20], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/tron-contrast.sublime-theme
+++ b/sublimeui/contrast/tron-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [110, 226, 255], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [27, 29, 31] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [87, 89, 91], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [110, 226, 255] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [110, 226, 255] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [0, 87, 141], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [17, 19, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [17, 19, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [17, 19, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [17, 19, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [17, 19, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [17, 19, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [17, 19, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [17, 19, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [17, 19, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [17, 19, 21], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/turnip-contrast.sublime-theme
+++ b/sublimeui/contrast/turnip-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [232, 218, 94], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [28, 28, 29] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [88, 88, 89], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [232, 218, 94] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [232, 218, 94] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [32, 85, 78], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [18, 18, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [18, 18, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [18, 18, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [18, 18, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [18, 18, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [18, 18, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [18, 18, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [18, 18, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [18, 18, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [18, 18, 19], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/contrast/zacks-contrast.sublime-theme
+++ b/sublimeui/contrast/zacks-contrast.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [188, 212, 42], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [20, 20, 20] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [80, 80, 80], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [188, 212, 42] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [188, 212, 42] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [215, 66, 16], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [10, 10, 10], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/crisp.sublime-theme
+++ b/sublimeui/crisp.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [252, 154, 15], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [54, 46, 54] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [114, 106, 114], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [252, 154, 15] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [252, 154, 15] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [78, 44, 80], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [44, 36, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [44, 36, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [44, 36, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [44, 36, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [44, 36, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [44, 36, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [44, 36, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [44, 36, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [44, 36, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [44, 36, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/darkside.sublime-theme
+++ b/sublimeui/darkside.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [242, 212, 44], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [54, 55, 56] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [114, 115, 116], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [242, 212, 44] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [242, 212, 44] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [192, 12, 0], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [44, 45, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [44, 45, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [44, 45, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [44, 45, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [44, 45, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [44, 45, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [44, 45, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [44, 45, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [44, 45, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [44, 45, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/earthsong.sublime-theme
+++ b/sublimeui/earthsong.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [248, 187, 57], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [74, 69, 64] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [134, 129, 124], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [248, 187, 57] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [248, 187, 57] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [179, 80, 37], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/freshcut.sublime-theme
+++ b/sublimeui/freshcut.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [233, 238, 0], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [67, 68, 68] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [127, 128, 128], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [233, 238, 0] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [233, 238, 0] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [0, 128, 158], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [57, 58, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [57, 58, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [57, 58, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [57, 58, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [57, 58, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [57, 58, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [57, 58, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [57, 58, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [57, 58, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [57, 58, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/frontier.sublime-theme
+++ b/sublimeui/frontier.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [248, 187, 57], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [74, 69, 64] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [134, 129, 124], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [248, 187, 57] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [248, 187, 57] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [202, 18, 18], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/github.sublime-theme
+++ b/sublimeui/github.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [155, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [221, 17, 68], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [255, 255, 255] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [175, 175, 175], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -567,7 +567,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -587,7 +587,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [221, 17, 68] // 0A
     },
@@ -595,7 +595,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -607,7 +607,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [221, 17, 68] // 08
     },
 
@@ -619,7 +619,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [70, 198, 198], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -637,7 +637,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -648,7 +648,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -875,7 +875,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -889,7 +889,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -902,7 +902,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -920,7 +920,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -933,7 +933,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -950,7 +950,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -963,7 +963,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -976,7 +976,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -994,7 +994,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1012,7 +1012,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/gloom.sublime-theme
+++ b/sublimeui/gloom.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [188, 212, 42], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [62, 71, 63] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [122, 131, 123], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [188, 212, 42] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [188, 212, 42] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [215, 53, 16], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [52, 61, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [52, 61, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [52, 61, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [52, 61, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [52, 61, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [52, 61, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [52, 61, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [52, 61, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [52, 61, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [52, 61, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/glowfish.sublime-theme
+++ b/sublimeui/glowfish.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [248, 187, 57], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [45, 51, 39] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [105, 111, 99], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [248, 187, 57] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [248, 187, 57] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [179, 80, 37], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [35, 41, 29], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [35, 41, 29], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [35, 41, 29], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [35, 41, 29], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [35, 41, 29], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [35, 41, 29], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [35, 41, 29], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [35, 41, 29], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [35, 41, 29], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [35, 41, 29], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/goldfish.sublime-theme
+++ b/sublimeui/goldfish.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [243, 110, 58], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [66, 71, 74] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [126, 131, 134], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [243, 110, 58] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [243, 110, 58] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [210, 65, 0], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [56, 61, 64], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [56, 61, 64], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [56, 61, 64], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [56, 61, 64], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [56, 61, 64], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [56, 61, 64], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [56, 61, 64], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [56, 61, 64], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [56, 61, 64], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [56, 61, 64], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/grunge.sublime-theme
+++ b/sublimeui/grunge.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [209, 242, 165], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [69, 71, 64] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [129, 131, 124], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [209, 242, 165] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [209, 242, 165] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [205, 65, 105], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [59, 61, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [59, 61, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [59, 61, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [59, 61, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [59, 61, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [59, 61, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [59, 61, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [59, 61, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [59, 61, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [59, 61, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/halflife.sublime-theme
+++ b/sublimeui/halflife.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [249, 212, 35], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [54, 54, 54] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [114, 114, 114], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [249, 212, 35] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [249, 212, 35] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [85, 97, 105], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/heroku.sublime-theme
+++ b/sublimeui/heroku.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [166, 250, 98], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [47, 47, 56] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [107, 107, 116], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [166, 250, 98] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [166, 250, 98] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [80, 75, 134], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [37, 37, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [37, 37, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [37, 37, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [37, 37, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [37, 37, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [37, 37, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [37, 37, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [37, 37, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [37, 37, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [37, 37, 46], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/hyrule.sublime-theme
+++ b/sublimeui/hyrule.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [206, 131, 13], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [65, 64, 63] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [125, 124, 123], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [206, 131, 13] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [206, 131, 13] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [46, 118, 0], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [55, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [55, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [55, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [55, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [55, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [55, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [55, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [55, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [55, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [55, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/iceberg.sublime-theme
+++ b/sublimeui/iceberg.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [255, 255, 255], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [70, 79, 81] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [130, 139, 141], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [255, 255, 255] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [255, 255, 255] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [5, 101, 121], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [60, 69, 71], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [60, 69, 71], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [60, 69, 71], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [60, 69, 71], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [60, 69, 71], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [60, 69, 71], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [60, 69, 71], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [60, 69, 71], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [60, 69, 71], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [60, 69, 71], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/juicy.sublime-theme
+++ b/sublimeui/juicy.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [59, 199, 184], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [54, 54, 54] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [114, 114, 114], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [59, 199, 184] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [59, 199, 184] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [19, 159, 144], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/keen.sublime-theme
+++ b/sublimeui/keen.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [181, 219, 153], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [37, 37, 37] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [97, 97, 97], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [181, 219, 153] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [181, 219, 153] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [95, 63, 143], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [27, 27, 27], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [27, 27, 27], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [27, 27, 27], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [27, 27, 27], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [27, 27, 27], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [27, 27, 27], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [27, 27, 27], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [27, 27, 27], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [27, 27, 27], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [27, 27, 27], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/kiwi.sublime-theme
+++ b/sublimeui/kiwi.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [161, 230, 193], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [42, 46, 45] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [102, 106, 105], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [161, 230, 193] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [161, 230, 193] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [109, 159, 2], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [32, 36, 35], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [32, 36, 35], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [32, 36, 35], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [32, 36, 35], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [32, 36, 35], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [32, 36, 35], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [32, 36, 35], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [32, 36, 35], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [32, 36, 35], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [32, 36, 35], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/laravel.sublime-theme
+++ b/sublimeui/laravel.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [253, 202, 73], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [66, 64, 63] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [126, 124, 123], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [253, 202, 73] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [253, 202, 73] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [212, 67, 0], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/lavender.sublime-theme
+++ b/sublimeui/lavender.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [245, 176, 239], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [61, 54, 66] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [121, 114, 126], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [245, 176, 239] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [245, 176, 239] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [142, 47, 215], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [51, 44, 56], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [51, 44, 56], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [51, 44, 56], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [51, 44, 56], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [51, 44, 56], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [51, 44, 56], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [51, 44, 56], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [51, 44, 56], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [51, 44, 56], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [51, 44, 56], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/legacy.sublime-theme
+++ b/sublimeui/legacy.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [255, 65, 13], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [40, 45, 51] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [100, 105, 111], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [255, 65, 13] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [255, 65, 13] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [0, 87, 141], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/light/earthsong-light.sublime-theme
+++ b/sublimeui/light/earthsong-light.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 232] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [248, 187, 57], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [255, 255, 255] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [175, 175, 175], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -567,7 +567,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -587,7 +587,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [248, 187, 57] // 0A
     },
@@ -595,7 +595,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -607,7 +607,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [248, 187, 57] // 08
     },
 
@@ -619,7 +619,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [255, 190, 147], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -637,7 +637,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -648,7 +648,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -875,7 +875,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -889,7 +889,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -902,7 +902,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -920,7 +920,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -933,7 +933,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -950,7 +950,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -963,7 +963,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -976,7 +976,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -994,7 +994,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1012,7 +1012,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [195, 195, 195], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/light/snappy-light.sublime-theme
+++ b/sublimeui/light/snappy-light.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 252, 238] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [78, 161, 223], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [255, 255, 255] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [158, 158, 158], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -567,7 +567,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -587,7 +587,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [78, 161, 223] // 0A
     },
@@ -595,7 +595,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -607,7 +607,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [78, 161, 223] // 08
     },
 
@@ -619,7 +619,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [255, 167, 153], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -637,7 +637,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -648,7 +648,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -875,7 +875,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [178, 178, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -889,7 +889,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [178, 178, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -902,7 +902,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [178, 178, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -920,7 +920,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [178, 178, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -933,7 +933,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [178, 178, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -950,7 +950,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [178, 178, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -963,7 +963,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [178, 178, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -976,7 +976,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [178, 178, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -994,7 +994,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [178, 178, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1012,7 +1012,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [178, 178, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/light/userscape.sublime-theme
+++ b/sublimeui/light/userscape.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [208, 246, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [227, 189, 20], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [255, 255, 255] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [165, 168, 172], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -567,7 +567,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -587,7 +587,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [227, 189, 20] // 0A
     },
@@ -595,7 +595,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -607,7 +607,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [227, 189, 20] // 08
     },
 
@@ -619,7 +619,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [123, 161, 210], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -637,7 +637,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -648,7 +648,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -875,7 +875,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [185, 188, 192], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -889,7 +889,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [185, 188, 192], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -902,7 +902,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [185, 188, 192], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -920,7 +920,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [185, 188, 192], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -933,7 +933,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [185, 188, 192], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -950,7 +950,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [185, 188, 192], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -963,7 +963,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [185, 188, 192], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -976,7 +976,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [185, 188, 192], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -994,7 +994,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [185, 188, 192], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1012,7 +1012,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [185, 188, 192], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/mellow.sublime-theme
+++ b/sublimeui/mellow.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [248, 187, 57], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [74, 69, 64] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [134, 129, 124], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [248, 187, 57] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [248, 187, 57] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [0, 89, 89], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [64, 59, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/mintchoc.sublime-theme
+++ b/sublimeui/mintchoc.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [0, 224, 140], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [63, 54, 48] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [123, 114, 108], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [0, 224, 140] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [0, 224, 140] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [0, 101, 58], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [53, 44, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [53, 44, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [53, 44, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [53, 44, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [53, 44, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [53, 44, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [53, 44, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [53, 44, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [53, 44, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [53, 44, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/mud.sublime-theme
+++ b/sublimeui/mud.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [181, 219, 153], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [84, 74, 73] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [144, 134, 133], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [181, 219, 153] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [181, 219, 153] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [215, 111, 95], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [74, 64, 63], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [74, 64, 63], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [74, 64, 63], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [74, 64, 63], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [74, 64, 63], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [74, 64, 63], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [74, 64, 63], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [74, 64, 63], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [74, 64, 63], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [74, 64, 63], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/otakon.sublime-theme
+++ b/sublimeui/otakon.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [158, 178, 217], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [43, 40, 43] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [103, 100, 103], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [158, 178, 217] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [158, 178, 217] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [206, 190, 195], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [33, 30, 33], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [33, 30, 33], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [33, 30, 33], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [33, 30, 33], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [33, 30, 33], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [33, 30, 33], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [33, 30, 33], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [33, 30, 33], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [33, 30, 33], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [33, 30, 33], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/pastel.sublime-theme
+++ b/sublimeui/pastel.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [197, 108, 108], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [54, 54, 54] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [114, 114, 114], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [197, 108, 108] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [197, 108, 108] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [0, 156, 125], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/patriot.sublime-theme
+++ b/sublimeui/patriot.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [55, 144, 222], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [65, 69, 71] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [125, 129, 131], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [55, 144, 222] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [55, 144, 222] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [6, 71, 177], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [55, 59, 61], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [55, 59, 61], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [55, 59, 61], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [55, 59, 61], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [55, 59, 61], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [55, 59, 61], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [55, 59, 61], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [55, 59, 61], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [55, 59, 61], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [55, 59, 61], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/peacock.sublime-theme
+++ b/sublimeui/peacock.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [188, 212, 42], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [63, 62, 59] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [123, 122, 119], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [188, 212, 42] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [188, 212, 42] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [215, 53, 16], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/peacocks-in-space.sublime-theme
+++ b/sublimeui/peacocks-in-space.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [188, 212, 42], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [63, 68, 79] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [123, 128, 139], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [188, 212, 42] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [188, 212, 42] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [215, 53, 16], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [53, 58, 69], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [53, 58, 69], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [53, 58, 69], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [53, 58, 69], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [53, 58, 69], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [53, 58, 69], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [53, 58, 69], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [53, 58, 69], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [53, 58, 69], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [53, 58, 69], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/peel.sublime-theme
+++ b/sublimeui/peel.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [244, 211, 112], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [55, 52, 48] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [115, 112, 108], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [244, 211, 112] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [244, 211, 112] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [171, 60, 19], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [45, 42, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [45, 42, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [45, 42, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [45, 42, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [45, 42, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [45, 42, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [45, 42, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [45, 42, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [45, 42, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [45, 42, 38], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/piggy.sublime-theme
+++ b/sublimeui/piggy.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [255, 69, 62], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [48, 42, 44] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [108, 102, 104], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [255, 69, 62] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [255, 69, 62] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [213, 66, 53], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [38, 32, 34], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [38, 32, 34], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [38, 32, 34], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [38, 32, 34], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [38, 32, 34], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [38, 32, 34], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [38, 32, 34], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [38, 32, 34], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [38, 32, 34], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [38, 32, 34], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/potpourri.sublime-theme
+++ b/sublimeui/potpourri.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [184, 102, 250], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [66, 63, 64] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [126, 123, 124], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [184, 102, 250] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [184, 102, 250] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [197, 0, 43], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [56, 53, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [56, 53, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [56, 53, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [56, 53, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [56, 53, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [56, 53, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [56, 53, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [56, 53, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [56, 53, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [56, 53, 54], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/rainbow.sublime-theme
+++ b/sublimeui/rainbow.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [199, 143, 235], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [42, 44, 46] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [102, 104, 106], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [199, 143, 235] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [199, 143, 235] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [199, 76, 71], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [32, 34, 36], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [32, 34, 36], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [32, 34, 36], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [32, 34, 36], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [32, 34, 36], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [32, 34, 36], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [32, 34, 36], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [32, 34, 36], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [32, 34, 36], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [32, 34, 36], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/revelation.sublime-theme
+++ b/sublimeui/revelation.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [255, 187, 41], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [66, 64, 63] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [126, 124, 123], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [255, 187, 41] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [255, 187, 41] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [57, 87, 120], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/shrek.sublime-theme
+++ b/sublimeui/shrek.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [129, 233, 17], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [54, 54, 54] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [114, 114, 114], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [129, 233, 17] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [129, 233, 17] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [93, 82, 54], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/slate.sublime-theme
+++ b/sublimeui/slate.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [158, 178, 217], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [45, 45, 51] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [105, 105, 111], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [158, 178, 217] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [158, 178, 217] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [97, 127, 137], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [35, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [35, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [35, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [35, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [35, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [35, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [35, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [35, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [35, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [35, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/slime.sublime-theme
+++ b/sublimeui/slime.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [250, 255, 219], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [61, 65, 68] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [121, 125, 128], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [250, 255, 219] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [250, 255, 219] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [119, 139, 154], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [51, 55, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [51, 55, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [51, 55, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [51, 55, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [51, 55, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [51, 55, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [51, 55, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [51, 55, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [51, 55, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [51, 55, 58], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/snappy.sublime-theme
+++ b/sublimeui/snappy.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [78, 161, 223], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [77, 77, 77] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [137, 137, 137], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [78, 161, 223] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [78, 161, 223] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [206, 57, 43], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [67, 67, 67], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [67, 67, 67], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [67, 67, 67], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [67, 67, 67], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [67, 67, 67], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [67, 67, 67], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [67, 67, 67], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [67, 67, 67], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [67, 67, 67], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [67, 67, 67], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/solarflare.sublime-theme
+++ b/sublimeui/solarflare.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [237, 229, 116], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [54, 54, 54] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [114, 114, 114], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [237, 229, 116] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [237, 229, 116] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [215, 38, 40], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/sourlick.sublime-theme
+++ b/sublimeui/sourlick.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [228, 255, 51], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [66, 64, 63] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [126, 124, 123], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [228, 255, 51] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [228, 255, 51] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [98, 154, 82], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/spearmint.sublime-theme
+++ b/sublimeui/spearmint.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [192, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [76, 215, 224], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [245, 255, 255] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [145, 160, 158], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -567,7 +567,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -587,7 +587,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [76, 215, 224] // 0A
     },
@@ -595,7 +595,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -607,7 +607,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [76, 215, 224] // 08
     },
 
@@ -619,7 +619,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [107, 198, 208], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -637,7 +637,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -648,7 +648,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -875,7 +875,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [165, 180, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -889,7 +889,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [165, 180, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -902,7 +902,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [165, 180, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -920,7 +920,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [165, 180, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -933,7 +933,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [165, 180, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -950,7 +950,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [165, 180, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -963,7 +963,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [165, 180, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -976,7 +976,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [165, 180, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -994,7 +994,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [165, 180, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1012,7 +1012,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [165, 180, 178], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/stark.sublime-theme
+++ b/sublimeui/stark.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [255, 187, 41], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [66, 64, 63] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [126, 124, 123], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [255, 187, 41] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [255, 187, 41] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [200, 9, 0], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [56, 54, 53], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/super.sublime-theme
+++ b/sublimeui/super.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [247, 162, 27], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [41, 45, 49] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [101, 105, 109], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [247, 162, 27] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [247, 162, 27] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [174, 0, 47], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [31, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [31, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [31, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [31, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [31, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [31, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [31, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [31, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [31, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [31, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/tonic.sublime-theme
+++ b/sublimeui/tonic.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [184, 205, 68], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [62, 67, 69] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [122, 127, 129], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [184, 205, 68] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [184, 205, 68] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [144, 165, 28], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [52, 57, 59], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [52, 57, 59], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [52, 57, 59], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [52, 57, 59], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [52, 57, 59], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [52, 57, 59], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [52, 57, 59], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [52, 57, 59], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [52, 57, 59], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [52, 57, 59], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/tribal.sublime-theme
+++ b/sublimeui/tribal.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [100, 174, 179], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [45, 45, 49] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [105, 105, 109], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [100, 174, 179] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [100, 174, 179] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [55, 45, 90], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [35, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [35, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [35, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [35, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [35, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [35, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [35, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [35, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [35, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [35, 35, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/tron.sublime-theme
+++ b/sublimeui/tron.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [110, 226, 255], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [40, 45, 51] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [100, 105, 111], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [110, 226, 255] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [110, 226, 255] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [0, 87, 141], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [30, 35, 41], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/turnip.sublime-theme
+++ b/sublimeui/turnip.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [232, 218, 94], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [46, 47, 49] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [106, 107, 109], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [232, 218, 94] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [232, 218, 94] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [32, 85, 78], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [36, 37, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [36, 37, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [36, 37, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [36, 37, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [36, 37, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [36, 37, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [36, 37, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [36, 37, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [36, 37, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [36, 37, 39], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/yule.sublime-theme
+++ b/sublimeui/yule.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [235, 182, 38], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [63, 62, 59] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [123, 122, 119], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [235, 182, 38] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [235, 182, 38] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [174, 9, 9], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [53, 52, 49], // 02
         "layer0.opacity": 1,
         "content_margin": 8

--- a/sublimeui/zacks.sublime-theme
+++ b/sublimeui/zacks.sublime-theme
@@ -67,7 +67,7 @@
     // Tab close button
     {
         "class": "tab_close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.tint": [255, 255, 255] // 03
     },
@@ -79,7 +79,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 1
     },
     {
@@ -98,7 +98,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.tint": [188, 212, 42], // 0A
         "layer0.opacity": 1
     },
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control","attributes": ["dirty","hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "attributes": ["hover"],
         "layer0.opacity": 1,
         "layer0.tint": [54, 54, 54] // 08
@@ -199,7 +199,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [114, 114, 114], // 04
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0,
@@ -213,7 +213,7 @@
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "fold_button_control",
@@ -565,7 +565,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.opacity": 0,
         "layer0.inner_margin": 0,
         "layer0.tint": [255, 255, 255], // 03
@@ -585,7 +585,7 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png",
+        "layer0.texture": "Theme - Spacegray/assets/circle.png",
         "layer0.opacity": 1,
         "layer0.tint": [188, 212, 42] // 0A
     },
@@ -593,7 +593,7 @@
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/circle.png"
+        "layer0.texture": "Theme - Spacegray/assets/circle.png"
     },
     // Sidebar file close hover
     {
@@ -605,7 +605,7 @@
         "class": "close_button",
         "attributes": ["dirty", "hover"],
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/close.png",
+        "layer0.texture": "Theme - Spacegray/assets/close.png",
         "layer0.tint": [188, 212, 42] // 08
     },
 
@@ -617,7 +617,7 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8,8],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-closed.png",
+        "layer0.texture": "Theme - Spacegray/assets/folder-closed.png",
         "layer0.tint": [215, 66, 16], // 02
         "layer0.opacity": 1,
         "layer0.inner_margin": 0
@@ -635,7 +635,7 @@
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
@@ -646,7 +646,7 @@
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
-        "layer0.texture": "Theme - Spacegray/Spacegray/folder-open.png"
+        "layer0.texture": "Theme - Spacegray/assets/folder-open.png"
     },
 
 //
@@ -872,7 +872,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Spacegray/Spacegray/regex.png",
+        "layer0.texture": "Theme - Spacegray/assets/regex.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -886,7 +886,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/casesens.png",
+        "layer0.texture": "Theme - Spacegray/assets/casesens.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -899,7 +899,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wholeword.png",
+        "layer0.texture": "Theme - Spacegray/assets/wholeword.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -917,7 +917,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Spacegray/Spacegray/context.png",
+        "layer0.texture": "Theme - Spacegray/assets/context.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -930,7 +930,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Spacegray/Spacegray/buffer.png",
+        "layer0.texture": "Theme - Spacegray/assets/buffer.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -947,7 +947,7 @@
     // Reverse search direction button (ST2 only)
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Spacegray/Spacegray/reverse.png",
+        "layer0.texture": "Theme - Spacegray/assets/reverse.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -960,7 +960,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Spacegray/Spacegray/wrap.png",
+        "layer0.texture": "Theme - Spacegray/assets/wrap.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -973,7 +973,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Spacegray/Spacegray/selection.png",
+        "layer0.texture": "Theme - Spacegray/assets/selection.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -991,7 +991,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Spacegray/Spacegray/lock.png",
+        "layer0.texture": "Theme - Spacegray/assets/lock.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8
@@ -1009,7 +1009,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Spacegray/Spacegray/highlight.png",
+        "layer0.texture": "Theme - Spacegray/assets/highlight.png",
         "layer0.tint": [44, 44, 44], // 02
         "layer0.opacity": 1,
         "content_margin": 8


### PR DESCRIPTION
This fixes icon problems after Spacegray theme update (#206)

@marcofugaro have changed paths a bit here https://github.com/kkga/spacegray/commit/a3cf933585ac8fbb67e02c350d9ee614642c17af

Before:
```
"layer0.texture": "Theme - Spacegray/Spacegray/close.png",
```
After:
```
"layer0.texture": "Theme - Spacegray/assets/close.png",
```
