### PR TITLE
fix(Vim): SignColumn

### DIFF
--- a/build/resources/patterns/vim/vim.pattern
+++ b/build/resources/patterns/vim/vim.pattern
@@ -19,6 +19,7 @@ hi link CursorIM Cursor
 hi Normal      guibg={{ background }}  guifg={{ foreground }}    gui=none ctermbg=0 ctermfg=15
 hi NonText     guibg=bg  guifg={{ foreground }}   ctermbg=8 ctermfg=14
 hi Visual      guibg=#557799  guifg=white    gui=none ctermbg=9 ctermfg=15
+hi SignColumn  guibg={{ background }}  guifg={{ foreground }}    gui=none ctermbg=0 ctermfg=15
 
 hi Linenr      guibg=bg       guifg=#aaaaaa  gui=none ctermbg=bg ctermfg=7
 


### PR DESCRIPTION
Make the Vim left hand gutter match the normal background.

Before
<img width="688" alt="before" src="https://user-images.githubusercontent.com/6437945/98849257-ed140e00-2420-11eb-9f3d-1003d5d7636b.png">

After
<img width="671" alt="after" src="https://user-images.githubusercontent.com/6437945/98849288-fa30fd00-2420-11eb-8a01-d2acde719a77.png">
